### PR TITLE
add continuous integration (CI) for linux build

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -1,0 +1,16 @@
+name: build-linux
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build-linux:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3 
+      - run: sudo apt install -y apt-utils build-essential wget qt5-qmake qt5-qmake-bin qt5-assistant qtbase5-dev qtmultimedia5-dev libqt5charts5 libqt5charts5-dev libqt5multimedia* libqt5datavisualization5-dev libqt5datavisualization5 libopencv-core-dev libopencv-core4.5d libopencv-dev libqwt-qt5-6 libqwt-qt5-dev libarmadillo-dev libarmadillo10
+      - run: qmake
+      - run: make -j4

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+.qmake.stash
+Makefile
+*.o
+moc_*
+qrc_*
+ui_*
+DFTFringe


### PR DESCRIPTION
This will automatically lead to a build on each PR for linux. Thanks @gr5 for having shared your dockerfile for building.
If build fails, we know we must not merge.
See github actions documentation to learn more. You have 2000m free per month on server for automated build; After that either you pay or it does not build anymore; But the free plan should be more than enough here.

I also added a .gitignore file to avoid adding unneeded files by error

I will add windows build in different PR because it's much more complex.
And the maybe continuous deployment (CD) to male release from a simple tag. But this is not a promise.