### PR TITLE
bump OpenCV from v3 to v4 on windows to have same build as linux

### DIFF
--- a/Circleoutline.h
+++ b/Circleoutline.h
@@ -23,7 +23,7 @@
 #include "gplus.h"
 #include <QVector>
 #include <QPointF>
-#include "opencv_win_linux.h"
+#include <opencv2/opencv.hpp>
 void fillCircle(cv::Mat &m, double cx, double cy, double rad, void *color);
 class CircleOutline: public boundary
 {

--- a/DFTFringe.pro
+++ b/DFTFringe.pro
@@ -352,12 +352,12 @@ FORMS    += mainwindow.ui \
 win32 {
       CONFIG( debug, debug|release ) {
         # debug
-        LIBS += D:\\qwt-6.1.5\\lib\\qwtd.dll
+        LIBS += D:\\qwt-6.1.6\\lib\\qwtd.dll
       } else {
         # release
-        LIBS += D:\\qwt-6.1.5\\lib\\qwt.dll
+        LIBS += D:\\qwt-6.1.6\\lib\\qwt.dll
       }
-      INCLUDEPATH += D:\\qwt-6.1.5\\src
+      INCLUDEPATH += D:\\qwt-6.1.6\\src
 
       #message("using win32")include
 
@@ -365,12 +365,12 @@ INCLUDEPATH += D:\armadillo\armadillo-9.200.6\include
 
 INCLUDEPATH += D:\opencv\opencv-3.4.12\build\install\include
 
-LIBS += D:\opencv\opencv-3.4.12\build\bin\libopencv_core3412.dll
-LIBS += D:\opencv\opencv-3.4.12\build\bin\libopencv_highgui3412.dll
-LIBS += D:\opencv\opencv-3.4.12\build\bin\libopencv_imgcodecs3412.dll
-LIBS += D:\opencv\opencv-3.4.12\build\bin\libopencv_imgproc3412.dll
-LIBS += D:\opencv\opencv-3.4.12\build\bin\libopencv_features2d3412.dll
-LIBS += D:\opencv\opencv-3.4.12\build\bin\libopencv_calib3d3412.dll
+LIBS += D:\opencv\build\bin\libopencv_core460.dll
+LIBS += D:\opencv\build\bin\libopencv_highgui460.dll
+LIBS += D:\opencv\build\bin\libopencv_imgcodecs460.dll
+LIBS += D:\opencv\build\bin\libopencv_imgproc460.dll
+LIBS += D:\opencv\build\bin\libopencv_features2d460.dll
+LIBS += D:\opencv\build\bin\libopencv_calib3d460.dll
 
 
 LIBS += D:\armadillo\bin\libarmadillo.dll

--- a/averagewavefrontfilesdlg.cpp
+++ b/averagewavefrontfilesdlg.cpp
@@ -3,7 +3,7 @@
 #include "surfacemanager.h"
 #include "mainwindow.h"
 #include "wavefrontaveragefilterdlg.h"
-#include "opencv_win_linux.h"
+#include <opencv2/opencv.hpp>
 #include "rejectedwavefrontsdlg.h"
 #include <QFileInfo>
 #include "utils.h"

--- a/camcalibrationreviewdlg.h
+++ b/camcalibrationreviewdlg.h
@@ -3,7 +3,7 @@
 
 #include <QDialog>
 #include <vector>
-#include "opencv_win_linux.h"
+#include <opencv2/opencv.hpp>
 
 namespace Ui {
 class CamCalibrationReviewDlg;

--- a/camwizardpage1.cpp
+++ b/camwizardpage1.cpp
@@ -4,7 +4,7 @@
 #include <opencv2/imgproc.hpp>
 #include <opencv2/calib3d/calib3d.hpp>
 #include <opencv2/highgui.hpp>
-#include "opencv_win_linux.h"
+#include <opencv2/opencv.hpp>
 #include <QImageReader>
 #include <QFileDialog>
 #include <vector>
@@ -16,10 +16,8 @@
 #include <QSettings>
 #include <QInputDialog>
 #include "settings2.h"
-#ifndef Q_OS_WIN
 #include <opencv2/core/types_c.h>
 #include <opencv2/core/core_c.h>
-#endif
 
 
 using namespace cv;

--- a/camwizardpage1.h
+++ b/camwizardpage1.h
@@ -8,7 +8,7 @@
 #include <opencv2/imgproc/imgproc.hpp>
 #include <opencv2/calib3d/calib3d.hpp>
 #include <opencv2/highgui/highgui.hpp>
-#include "opencv_win_linux.h"
+#include <opencv2/opencv.hpp>
 namespace Ui {
 class CamWizardPage1;
 }

--- a/colorchanneldisplay.cpp
+++ b/colorchanneldisplay.cpp
@@ -17,7 +17,7 @@
 ****************************************************************************/
 #include "colorchanneldisplay.h"
 #include "ui_colorchanneldisplay.h"
-#include "opencv_win_linux.h"
+#include <opencv2/opencv.hpp>
 
 ColorChannelDisplay::ColorChannelDisplay(QWidget *parent) :
     QDialog(parent),

--- a/contourplot.cpp
+++ b/contourplot.cpp
@@ -29,16 +29,12 @@
 #include <qwt_plot_renderer.h>
 #include <qwt_plot_grid.h>
 #include "contourplot.h"
-#include "opencv_win_linux.h"
+#include <opencv2/opencv.hpp>
 #include "wavefront.h"
 #include <QtGui/qevent.h>
 #include <qwt_plot_rescaler.h>
 #include <QtGui>
-#ifndef Q_OS_WIN
 #include <opencv2/highgui/highgui.hpp>
-#else
-#include "opencv/highgui.h"
-#endif
 #include "dftcolormap.h"
 #include <QDebug>
 #include <math.h>

--- a/contourplot.h
+++ b/contourplot.h
@@ -20,7 +20,7 @@
 
 #include <qwt_plot.h>
 #include <qwt_plot_spectrogram.h>
-#include "opencv_win_linux.h"
+#include <opencv2/opencv.hpp>
 #include "wavefront.h"
 #include "contourtools.h"
 #include "usercolormapdlg.h"

--- a/dftarea.h
+++ b/dftarea.h
@@ -19,12 +19,8 @@
 #define DFTAREA_H
 
 #include <QWidget>
-#include "opencv_win_linux.h"
-#ifndef Q_OS_WIN
+#include <opencv2/opencv.hpp>
 #include <opencv2/highgui/highgui.hpp>
-#else
-#include <opencv/highgui.h>
-#endif
 #include "IgramArea.h"
 #include "dfttools.h"
 #include <QImage>

--- a/foucaultview.cpp
+++ b/foucaultview.cpp
@@ -1,12 +1,8 @@
 #include "foucaultview.h"
 #include "ui_foucaultview.h"
 #include "mirrordlg.h"
-#include "opencv_win_linux.h"
-#ifndef Q_OS_WIN
+#include <opencv2/opencv.hpp>
 #include <opencv2/highgui/highgui.hpp>
-#else
-#include <opencv/highgui.h>
-#endif
 #include "simulationsview.h"
 #include <QVector>
 #include <QMenu>

--- a/igramarea.cpp
+++ b/igramarea.cpp
@@ -26,7 +26,7 @@
 #include <QtGlobal>
 #include <math.h>
 
-#include "opencv_win_linux.h"
+#include <opencv2/opencv.hpp>
 #include "opencv2/imgproc.hpp"
 #include "opencv2/features2d.hpp"
 #include "graphicsutilities.h"

--- a/imagehisto.cpp
+++ b/imagehisto.cpp
@@ -16,9 +16,7 @@
 
 ****************************************************************************/
 #include "imagehisto.h"
-#ifndef Q_OS_WIN
 #include <opencv2/core/core_c.h>
-#endif
 #include <iostream>
 
 using namespace cv;

--- a/imagehisto.h
+++ b/imagehisto.h
@@ -19,7 +19,7 @@
 #define IMAGEHISTO_H
 #include "opencv2/imgproc/imgproc.hpp"
 #include "opencv2/highgui/highgui.hpp"
-#include "opencv_win_linux.h"
+#include <opencv2/opencv.hpp>
 class imageHisto
 {
 public:

--- a/intensityplot.cpp
+++ b/intensityplot.cpp
@@ -36,11 +36,7 @@
 #include <qwt_symbol.h>
 #include <qwt_math.h>
 #include <math.h>
-#ifndef Q_OS_WIN
 #include <opencv2/highgui/highgui.hpp>
-#else
-#include <opencv/highgui.h>
-#endif
 #include <qevent.h>
 #include <qwt_scale_draw.h>
 #include "opencv2/opencv.hpp"

--- a/intensityplot.h
+++ b/intensityplot.h
@@ -19,7 +19,7 @@
 #define INTENSITYPLOT_H
 #include <QWidget>
 #include <qwt_plot.h>
-#include "opencv_win_linux.h"
+#include <opencv2/opencv.hpp>
 
 class intensityPlot:  public QwtPlot
 {

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -33,7 +33,7 @@
 #include "simigramdlg.h"
 #include "usercolormapdlg.h"
 #include <qlayout.h>
-#include "opencv_win_linux.h"
+#include <opencv2/opencv.hpp>
 #include "simulationsview.h"
 #include "outlinehelpdocwidget.h"
 #include "bathastigdlg.h"

--- a/nullvariationdlg.cpp
+++ b/nullvariationdlg.cpp
@@ -13,7 +13,7 @@
 #include "QLayout"
 #include "plotcolor.h"
 #include "qwt_legend.h"
-#include "opencv_win_linux.h"
+#include <opencv2/opencv.hpp>
 #include <random>
 
 nullVariationDlg::nullVariationDlg(QWidget *parent) :

--- a/opencv_win_linux.h
+++ b/opencv_win_linux.h
@@ -1,5 +1,0 @@
-#ifndef Q_OS_WIN
-#include <opencv2/opencv.hpp>
-#else
-#include <opencv/cv.h>
-#endif

--- a/outlinedialog.cpp
+++ b/outlinedialog.cpp
@@ -6,9 +6,7 @@
 #include <QMessageBox>
 #include <QShortcut>
 #include <QMouseEvent>
-#ifndef Q_OS_WIN
 #include <opencv2/imgproc.hpp>
-#endif
 
 outlineDialog::outlineDialog(double x, double y, double rad, QWidget *parent) :
     m_x(x),m_y(y),m_rad(rad),

--- a/outlinedialog.h
+++ b/outlinedialog.h
@@ -3,12 +3,9 @@
 
 #include <QDialog>
 #include "opencv2/imgproc/imgproc.hpp"
-#include "opencv_win_linux.h"
-#ifndef Q_OS_WIN
+#include <opencv2/opencv.hpp>
 #include <opencv2/highgui/highgui.hpp>
-#else
-#include <opencv/highgui.h>
-#endif
+
 namespace Ui {
 class outlineDialog;
 }

--- a/pixelstats.h
+++ b/pixelstats.h
@@ -2,7 +2,7 @@
 #define PIXELSTATS_H
 
 #include <QWidget>
-#include "opencv_win_linux.h"
+#include <opencv2/opencv.hpp>
 #include "wavefront.h"
 #include <qwt_plot.h>
 #include <QScrollArea>

--- a/profileplot.h
+++ b/profileplot.h
@@ -26,7 +26,7 @@
 #include "contourtools.h"
 #include <qwt_compass.h>
 #include <qwt_dial.h>
-#include "opencv_win_linux.h"
+#include <opencv2/opencv.hpp>
 #include <QRadioButton>
 #include <QCheckBox>
 #include <QDoubleSpinBox>

--- a/psfplot.h
+++ b/psfplot.h
@@ -21,7 +21,7 @@
 #include <QWidget>
 #include <qwt_plot.h>
 #include "wavefront.h"
-#include "opencv_win_linux.h"
+#include <opencv2/opencv.hpp>
 #include <qwt_plot_legenditem.h>
 #include <qwt_legend.h>
 #include <qwt_plot_legenditem.h>

--- a/psi_dlg.h
+++ b/psi_dlg.h
@@ -2,7 +2,7 @@
 #define PSI_DLG_H
 
 #include <QDialog>
-#include "opencv_win_linux.h"
+#include <opencv2/opencv.hpp>
 class PSITiltOptions;
 namespace Ui {
 class PSI_dlg;

--- a/psiphasedisplay.cpp
+++ b/psiphasedisplay.cpp
@@ -1,11 +1,7 @@
 #include "psiphasedisplay.h"
 #include "ui_psiphasedisplay.h"
 #include "math.h"
-#ifndef Q_OS_WIN
 #include <opencv2/highgui/highgui.hpp>
-#else
-#include <opencv/highgui.h>
-#endif
 #include <qdebug.h>
 #include <qimage.h>
 #include <qpainter.h>

--- a/psiphasedisplay.h
+++ b/psiphasedisplay.h
@@ -2,7 +2,7 @@
 #define PSIPHASEDISPLAY_H
 
 #include <QDialog>
-#include "opencv_win_linux.h"
+#include <opencv2/opencv.hpp>
 
 namespace Ui {
 class PSIphaseDisplay;

--- a/punwrap.h
+++ b/punwrap.h
@@ -17,12 +17,9 @@
 ****************************************************************************/
 #ifndef PUNWRAP_H
 #define PUNWRAP_H
-#include "opencv_win_linux.h"
-#ifndef Q_OS_WIN
+#include <opencv2/opencv.hpp>
 #include <opencv2/highgui/highgui.hpp>
-#else
-#include <opencv/highgui.h>
-#endif
+
 void unwrap(double *pphase, double *unwrapped, char *mask, int nx, int ny);
 
 

--- a/rotationdlg.cpp
+++ b/rotationdlg.cpp
@@ -17,16 +17,14 @@
 ****************************************************************************/
 #include "rotationdlg.h"
 #include "ui_rotationdlg.h"
-#include "opencv_win_linux.h"
+#include <opencv2/opencv.hpp>
 #include <qsettings.h>
 
-#ifndef Q_OS_WIN
 #define CV_INTER_NN cv::INTER_NEAREST
 #define CV_INTER_LINEAR cv::INTER_LINEAR
 #define CV_INTER_LANCZOS4 cv::INTER_LANCZOS4
 #define CV_INTER_CUBIC cv::INTER_CUBIC
 #define CV_INTER_AREA cv::INTER_AREA
-#endif
 
 RotationDlg::RotationDlg( QList<int> list, QWidget *parent) :
     QDialog(parent),

--- a/simulationsview.cpp
+++ b/simulationsview.cpp
@@ -17,7 +17,7 @@
 ****************************************************************************/
 #include "simulationsview.h"
 #include "ui_simulationsview.h"
-#include "opencv_win_linux.h"
+#include <opencv2/opencv.hpp>
 #include <opencv2/imgproc.hpp>
 #include "mirrordlg.h"
 #include "zernikeprocess.h"
@@ -34,9 +34,8 @@
 #include "utils.h"
 #include <QTextDocument>
 #include <QtMath>
-#ifndef Q_OS_WIN
 #include <opencv2/core/core_c.h>
-#endif
+
 double M2PI = M_PI * 2.;
 SimulationsView *SimulationsView::m_Instance = 0;
 class arcSecScaleDraw: public QwtScaleDraw

--- a/simulationsview.h
+++ b/simulationsview.h
@@ -20,7 +20,7 @@
 
 #include <QWidget>
 #include "wavefront.h"
-#include "opencv_win_linux.h"
+#include <opencv2/opencv.hpp>
 #include <QTimer>
 #include <QtDataVisualization/Q3DSurface>
 class arcSecScaleDraw;

--- a/statsview.cpp
+++ b/statsview.cpp
@@ -6,7 +6,7 @@
 #include "mirrordlg.h"
 #include <QFileDialog>
 #include <QPrinter>
-#include "opencv_win_linux.h"
+#include <opencv2/opencv.hpp>
 #include <QApplication>
 #include <QMessageBox>
 #include "myutils.h"

--- a/surfaceanalysistools.h
+++ b/surfaceanalysistools.h
@@ -23,7 +23,7 @@
 #include <QLabel>
 #include <QList>
 #include <QTimer>
-#include "opencv_win_linux.h"
+#include <opencv2/opencv.hpp>
 namespace Ui {
 class surfaceAnalysisTools;
 }

--- a/surfacemanager.cpp
+++ b/surfacemanager.cpp
@@ -19,7 +19,7 @@
 #include <limits>
 #include <cmath>
 #include <QWidget>
-#include "opencv_win_linux.h"
+#include <opencv2/opencv.hpp>
 #include <QtWidgets/QMessageBox>
 #include <QDebug>
 #include "mainwindow.h"

--- a/transformwavefrontdlg.cpp
+++ b/transformwavefrontdlg.cpp
@@ -1,11 +1,7 @@
 #include "transformwavefrontdlg.h"
 #include "ui_transformwavefrontdlg.h"
-#include "opencv_win_linux.h"
-#ifndef Q_OS_WIN
+#include <opencv2/opencv.hpp>
 #include <opencv2/highgui/highgui.hpp>
-#else
-#include <opencv/highgui.h>
-#endif
 #include "surfacemanager.h"
 TransformWaveFrontDlg::TransformWaveFrontDlg( QWidget *parent) :
     QDialog(parent),

--- a/unwraperrorsview.cpp
+++ b/unwraperrorsview.cpp
@@ -1,6 +1,6 @@
 #include "unwraperrorsview.h"
 #include "ui_unwraperrorsview.h"
-#include "opencv_win_linux.h"
+#include <opencv2/opencv.hpp>
 #include <opencv2/imgproc.hpp>
 #include <QSettings>
 #include <QFile>

--- a/vortex.h
+++ b/vortex.h
@@ -17,7 +17,7 @@
 ****************************************************************************/
 #ifndef VORTEX_H
 #define VORTEX_H
-#include "opencv_win_linux.h"
+#include <opencv2/opencv.hpp>
 
 void vortex(cv::Mat &dft, const char *ext,
            double low, double smooth,

--- a/wavefront.h
+++ b/wavefront.h
@@ -17,7 +17,7 @@
 ****************************************************************************/
 #ifndef WAVEFRONT_H
 #define WAVEFRONT_H
-#include "opencv_win_linux.h"
+#include <opencv2/opencv.hpp>
 #include "Circleoutline.h"
 #include <QPointF>
 class wavefront

--- a/wftexaminer.cpp
+++ b/wftexaminer.cpp
@@ -27,7 +27,7 @@
 #include <qwt_interval_symbol.h>
 #include <qwt_plot_intervalcurve.h>
 #include <qwt_scale_engine.h>
-#include "opencv_win_linux.h"
+#include <opencv2/opencv.hpp>
 wftExaminer::wftExaminer( wavefront *wf,QWidget *parent) :
     QDialog(parent),m_wf(wf),
     curve(0),maskCurve(0),ui(new Ui::wftExaminer)

--- a/zernikedlg.h
+++ b/zernikedlg.h
@@ -23,7 +23,7 @@
 #include <QtGui>
 #include "zernikedlg.h"
 #include <QAbstractTableModel>
-#include "opencv_win_linux.h"
+#include <opencv2/opencv.hpp>
 #include <vector>
 #include <QVector>
 

--- a/zernikeprocess.cpp
+++ b/zernikeprocess.cpp
@@ -16,7 +16,7 @@
 
 ****************************************************************************/
 #include "zernikeprocess.h"
-#include "opencv_win_linux.h"
+#include <opencv2/opencv.hpp>
 #include <cmath>
 #include "mainwindow.h"
 #include <QDebug>


### PR DESCRIPTION
Hi @githubdoe 

After all these month I have finally been able to build on windows locally.
I used latest version of everything I found and many discrepancies between linux and windows build were only due to different version of openCV. I think it simplifies much if everybody uses openCV v4. 
Many deprecation warnings are here during build, I don't know if this was already on your build, anyway it can be fixed later in different PR.

I tried to change the `.pro` file minimally for you so I have not been able to test _this exact_ file.
I you think the idea is good, could you please try this build with latest openCV on your side ?

In the meantime I will work on CI/CD for Windows to avoid this work in futur.
