### PR TITLE
Fix missing icon in windows build

### DIFF
--- a/DFTFringe.rc
+++ b/DFTFringe.rc
@@ -1,1 +1,1 @@
-IDI_ICON1	ICON DISCARDABLE "icon.ico"
+IDI_ICON1	ICON DISCARDABLE "res/surface_LeY_icon.ico"


### PR DESCRIPTION
@githubdoe  I dont know how you build manually on your computer but without copying icon.ico or other changes it does not work on a clean build.

This fixes windows build. Note I don't know why it's not needed by Linux. Also we will see if it breaks Linux build thanks to CI