### PR TITLE
Windows CI build

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -130,7 +130,7 @@ jobs:
       - name: install qmake
         if: steps.cache-QWT.outputs.cache-hit != 'true'
         run: aqt install-qt windows desktop 5.15.2 win64_mingw81 --archives qtbase qtsvg
-      - name: qmaje
+      - name: qmake
         if: steps.cache-QWT.outputs.cache-hit != 'true'
         run: cd qwt-6.1.6 ; ..\5.15.2\mingw81_64\bin\qmake.exe
       - name: build

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -1,0 +1,332 @@
+name: build-windows
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  cache-mingw-from-QT:
+    runs-on: windows-latest
+    steps:
+      # this will restore/cache everything in /Tools depending on cache hit/miss
+      - name: Cache minGW
+        id: cache-minGW
+        uses: actions/cache@v3
+        with:
+          path: Tools
+          key: ${{ runner.os }}-mingw810_64
+
+      # all what follows is only run on cache miss
+      - name: install aqtinstall tool
+        if: steps.cache-minGW.outputs.cache-hit != 'true'
+        run: pip install aqtinstall
+      - name: install correct minGW version 
+        if: steps.cache-minGW.outputs.cache-hit != 'true'
+        run: aqt install-tool windows desktop tools_mingw qt.tools.win64_mingw810
+        # path is Tools\mingw810_64\bin
+
+  build-openCV-with-QT:
+    runs-on: windows-latest
+    needs: cache-mingw-from-QT
+    steps:
+      # this will restore/cache everything depending on cache hit/miss
+      - name: Cache QT and openCV
+        uses: actions/cache/@v3
+        id: cache-openCV-QT
+        with:
+          path: |
+            build_openCV\install\x64\mingw\bin\*.dll
+            build_openCV\install\include\*
+            5.15.2\mingw81_64\bin\*
+            5.15.2\mingw81_64\include\*
+            5.15.2\mingw81_64\lib\*
+            5.15.2\mingw81_64\mkspecs\*
+            5.15.2\mingw81_64\plugins\platforms\*
+            5.15.2\mingw81_64\plugins\imageformats\*
+          key: ${{ runner.os }}-openCV-4.6.0-QT-5.15.2
+
+      # all what follows is only run on cache miss
+
+      # restore cached minGW
+      - uses: actions/cache/restore@v3
+        if: steps.cache-openCV-QT.outputs.cache-hit != 'true'
+        id: cache-minGW
+        with:
+          path: Tools
+          key: ${{ runner.os }}-mingw810_64
+          fail-on-cache-miss: true
+      - name: add minGW to path
+        if: steps.cache-openCV-QT.outputs.cache-hit != 'true'
+        shell: bash
+        run: echo "${{github.workspace}}\Tools\mingw810_64\bin" >> $GITHUB_PATH
+      - name: install aqtinstall tool
+        if: steps.cache-openCV-QT.outputs.cache-hit != 'true'
+        run: pip install aqtinstall
+      - name: install QT
+        if: steps.cache-openCV-QT.outputs.cache-hit != 'true'
+        run: aqt install-qt windows desktop 5.15.2 win64_mingw81 -m qtcharts qtdatavis3d
+      - uses: actions/checkout@v3
+        if: steps.cache-openCV-QT.outputs.cache-hit != 'true'
+        with: 
+          repository: 'opencv/opencv'
+          ref: '4.6.0'
+          path: './openCV'
+      - name: cmake generate
+        if: steps.cache-openCV-QT.outputs.cache-hit != 'true'
+        run: cmake -G "MinGW Makefiles" -S openCV -B build_openCV -D WITH_QT=ON -D WITH_OPENGL=ON -D Qt5_DIR=:./5.15.2/mingw81_64/lib/cmake/Qt5
+      - name: cmake generate again
+        if: steps.cache-openCV-QT.outputs.cache-hit != 'true'
+        run: cmake -G "MinGW Makefiles" -S openCV -B build_openCV
+      - name: cmake build
+        if: steps.cache-openCV-QT.outputs.cache-hit != 'true'
+        run: cmake --build ./build_openCV -j4
+      - name: cmake install
+        if: steps.cache-openCV-QT.outputs.cache-hit != 'true'
+        run: cmake --install ./build_openCV
+
+  build-QWT:
+    runs-on: windows-latest
+    needs: cache-mingw-from-QT
+    steps:
+      # this will restore/cache everything depending on cache hit/miss
+      - name: cache QWT
+        uses: actions/cache/@v3
+        id: cache-QWT
+        with:
+          path: |
+            qwt-6.1.6\src
+            qwt-6.1.6\lib\*.dll
+          key: ${{ runner.os }}-QWT-6.1.6
+
+      # all what follows is only run on cache miss
+
+      # restore cached minGW
+      - uses: actions/cache/restore@v3
+        if: steps.cache-QWT.outputs.cache-hit != 'true'
+        id: cache-minGW
+        with:
+          path: Tools
+          key: ${{ runner.os }}-mingw810_64
+          fail-on-cache-miss: true
+      - name: add minGW to path
+        if: steps.cache-QWT.outputs.cache-hit != 'true'
+        shell: bash
+        run: echo "${{github.workspace}}\Tools\mingw810_64\bin" >> $GITHUB_PATH
+      - name: install wget
+        if: steps.cache-QWT.outputs.cache-hit != 'true'
+        run: choco install -y wget
+      - name: download QWT
+        if: steps.cache-QWT.outputs.cache-hit != 'true'
+        # I specified the mirror because one of the random mirrors did not work during my tests
+        run: wget -O qwt-6.1.6.zip https://sourceforge.net/projects/qwt/files/qwt/6.1.6/qwt-6.1.6.zip/download?use_mirror=pilotfiber
+      - name: extract archive
+        if: steps.cache-QWT.outputs.cache-hit != 'true'
+        run: 7z x qwt-6.1.6.zip
+      - name: install aqtinstall tool
+        if: steps.cache-QWT.outputs.cache-hit != 'true'
+        run: pip install aqtinstall
+      - name: install qmake
+        if: steps.cache-QWT.outputs.cache-hit != 'true'
+        run: aqt install-qt windows desktop 5.15.2 win64_mingw81 --archives qtbase qtsvg
+      - name: qmaje
+        if: steps.cache-QWT.outputs.cache-hit != 'true'
+        run: cd qwt-6.1.6 ; ..\5.15.2\mingw81_64\bin\qmake.exe
+      - name: build
+        if: steps.cache-QWT.outputs.cache-hit != 'true'
+        run: cd qwt-6.1.6 ; mingw32-make -j4
+
+  build-armadillo:
+    runs-on: windows-latest
+    needs: cache-mingw-from-QT
+    steps:
+      # this will restore/cache everything depending on cache hit/miss
+      - name: Cache armadillo build
+        id: cache-armadillo
+        uses: actions/cache@v3
+        with:
+          path: |
+            build_armadillo\libarmadillo.dll
+            build_armadillo\tmp\include
+          key: ${{ runner.os }}-armadillo-11.4.0
+
+      # all what follows is only run on cache miss
+
+      # restore cached minGW
+      - uses: actions/cache/restore@v3
+        if: steps.cache-armadillo.outputs.cache-hit != 'true'
+        id: cache-minGW
+        with:
+          path: Tools
+          key: ${{ runner.os }}-mingw810_64
+          fail-on-cache-miss: true
+      - name: add minGW to path
+        if: steps.cache-armadillo.outputs.cache-hit != 'true'
+        shell: bash
+        run: echo "${{github.workspace}}\Tools\mingw810_64\bin" >> $GITHUB_PATH
+      - name: install wget
+        if: steps.cache-armadillo.outputs.cache-hit != 'true'
+        run: choco install -y wget
+      - name: download armadillo
+        if: steps.cache-armadillo.outputs.cache-hit != 'true'
+        # I specified the mirror because one of the random mirrors did not work during my tests
+        run: wget -O armadillo-11.4.4.tar.xz http://sourceforge.net/projects/arma/files/armadillo-11.4.4.tar.xz/download?use_mirror=versaweb
+      # Extract in two step. First step write to stdo and second step read from stdi.
+      # This avoids intermediate file creation
+      # It must run in CMD because powershell corrupts pipes
+      - name: extract archive
+        if: steps.cache-armadillo.outputs.cache-hit != 'true'
+        run: 7z x -so armadillo-11.4.4.tar.xz | 7z x -si -ttar
+        shell: cmd
+      - name: cmake generate
+        if: steps.cache-armadillo.outputs.cache-hit != 'true'
+        run: cmake -G "MinGW Makefiles" -S armadillo-11.4.4 -B build_armadillo
+      - name: cmake build
+        if: steps.cache-armadillo.outputs.cache-hit != 'true'
+        run: cmake --build ./build_armadillo -j4
+
+  build-lapack:
+    runs-on: windows-latest
+    needs: cache-mingw-from-QT
+    steps:
+      # this will restore/cache everything depending on cache hit/miss
+      - name: Cache lapack build
+        id: cache-lapack
+        uses: actions/cache@v3
+        with:
+          path: |
+            build_lapack\lib\liblapack.a
+            build_lapack\lib\libblas.a
+          key: ${{ runner.os }}-lapack-3.11.0
+
+      # all what follows is only run on cache miss
+
+      # restore cached minGW
+      - uses: actions/cache/restore@v3
+        if: steps.cache-lapack.outputs.cache-hit != 'true'
+        id: cache-minGW
+        with:
+          path: Tools
+          key: ${{ runner.os }}-mingw810_64
+          fail-on-cache-miss: true
+      - name: add minGW to path
+        if: steps.cache-lapack.outputs.cache-hit != 'true'
+        shell: bash
+        run: echo "${{github.workspace}}\Tools\mingw810_64\bin" >> $GITHUB_PATH
+      - uses: actions/checkout@v3 
+        if: steps.cache-lapack.outputs.cache-hit != 'true'
+        with: 
+          repository: 'Reference-LAPACK/lapack'
+          ref: 'v3.11.0'
+          path: './lapack'
+      # remove test compiler because https://github.com/Reference-LAPACK/lapack/issues/305 not needed to create DLL
+      - name: cmake generate
+        if: steps.cache-lapack.outputs.cache-hit != 'true'
+        run: cmake -G "MinGW Makefiles" -S lapack -B build_lapack -D TEST_FORTRAN_COMPILER=OFF
+      - name: cmake build
+        if: steps.cache-lapack.outputs.cache-hit != 'true'
+        run: cmake --build ./build_lapack -j4
+
+
+  build-DFTFringe:
+    runs-on: windows-latest
+    needs: [cache-mingw-from-QT, build-lapack, build-armadillo, build-QWT, build-openCV-with-QT]
+    steps:
+      # restore cached minGW
+      - uses: actions/cache/restore@v3
+        id: cache-minGW
+        with:
+          path: Tools
+          key: ${{ runner.os }}-mingw810_64
+          fail-on-cache-miss: true
+      - name: add minGW to path
+        shell: bash
+        run: echo "${{github.workspace}}\Tools\mingw810_64\bin" >> $GITHUB_PATH
+      # restore cached lapack
+      - uses: actions/cache/restore@v3
+        id: cache-lapack
+        with:
+          path: |
+            build_lapack\lib\liblapack.a
+            build_lapack\lib\libblas.a
+          key: ${{ runner.os }}-lapack-3.11.0
+          fail-on-cache-miss: true
+      # restore cached armadillo
+      - uses: actions/cache/restore@v3
+        id: cache-armadillo
+        with:
+          path: |
+            build_armadillo\libarmadillo.dll
+            build_armadillo\tmp\include
+          key: ${{ runner.os }}-armadillo-11.4.0
+          fail-on-cache-miss: true
+      # restore cached QWT
+      - uses: actions/cache/restore@v3
+        id: cache-QWT
+        with:
+          path: |
+            qwt-6.1.6\src
+            qwt-6.1.6\lib\*.dll
+          key: ${{ runner.os }}-QWT-6.1.6
+          fail-on-cache-miss: true
+      # restore cached openCV and QT
+      - uses: actions/cache/restore@v3
+        id: cache-openCV-QT
+        with:
+          path: |
+            build_openCV\install\x64\mingw\bin\*.dll
+            build_openCV\install\include\*
+            5.15.2\mingw81_64\bin\*
+            5.15.2\mingw81_64\include\*
+            5.15.2\mingw81_64\lib\*
+            5.15.2\mingw81_64\mkspecs\*
+            5.15.2\mingw81_64\plugins\platforms\*
+            5.15.2\mingw81_64\plugins\imageformats\*
+          key: ${{ runner.os }}-openCV-4.6.0-QT-5.15.2
+          fail-on-cache-miss: true
+      
+      - uses: actions/checkout@v3
+        with: 
+          path: 'DFTFringe'
+
+      - run: cd DFTFringe ; ..\5.15.2\mingw81_64\bin\qmake.exe
+      - run: cd DFTFringe ; mingw32-make -j4
+      - name: copy needed dlls
+        run: |
+          mkdir artifactFolder
+          Copy-Item DFTFringe\res -Destination artifactFolder\res -Recurse
+          Copy-Item DFTFringe\ColorMaps -Destination artifactFolder\ColorMaps -Recurse
+          Copy-Item DFTFringe\release\DFTFringe.exe -Destination artifactFolder
+          mkdir artifactFolder\platforms
+          Copy-Item 5.15.2\mingw81_64\plugins\platforms\qwindows.dll -Destination artifactFolder\platforms
+          Copy-Item 5.15.2\mingw81_64\plugins\imageformats -Destination artifactFolder\imageformats -Recurse
+          Copy-Item build_openCV\install\x64\mingw\bin\libopencv_calib3d460.dll -Destination artifactFolder
+          Copy-Item build_openCV\install\x64\mingw\bin\libopencv_core460.dll -Destination artifactFolder
+          Copy-Item build_openCV\install\x64\mingw\bin\libopencv_features2d460.dll -Destination artifactFolder
+          Copy-Item build_openCV\install\x64\mingw\bin\libopencv_flann460.dll -Destination artifactFolder
+          Copy-Item build_openCV\install\x64\mingw\bin\libopencv_highgui460.dll -Destination artifactFolder
+          Copy-Item build_openCV\install\x64\mingw\bin\libopencv_imgcodecs460.dll -Destination artifactFolder
+          Copy-Item build_openCV\install\x64\mingw\bin\libopencv_imgproc460.dll -Destination artifactFolder
+          Copy-Item qwt-6.1.6\lib\qwt.dll -Destination artifactFolder
+          Copy-Item 5.15.2\mingw81_64\bin\Qt5Charts.dll -Destination artifactFolder
+          Copy-Item 5.15.2\mingw81_64\bin\Qt5Core.dll -Destination artifactFolder
+          Copy-Item 5.15.2\mingw81_64\bin\Qt5DataVisualization.dll -Destination artifactFolder
+          Copy-Item 5.15.2\mingw81_64\bin\Qt5Gui.dll -Destination artifactFolder
+          Copy-Item 5.15.2\mingw81_64\bin\Qt5Network.dll -Destination artifactFolder
+          Copy-Item 5.15.2\mingw81_64\bin\Qt5PrintSupport.dll -Destination artifactFolder
+          Copy-Item 5.15.2\mingw81_64\bin\Qt5Widgets.dll -Destination artifactFolder
+          Copy-Item 5.15.2\mingw81_64\bin\libgcc_s_seh-1.dll -Destination artifactFolder
+          Copy-Item 5.15.2\mingw81_64\bin\libstdc++-6.dll -Destination artifactFolder
+          Copy-Item 5.15.2\mingw81_64\bin\libwinpthread-1.dll -Destination artifactFolder
+          Copy-Item Tools\mingw810_64\bin\libquadmath-0.dll -Destination artifactFolder
+          Copy-Item 5.15.2\mingw81_64\bin\Qt5OpenGL.dll -Destination artifactFolder
+          Copy-Item 5.15.2\mingw81_64\bin\QT5Test.dll -Destination artifactFolder
+          Copy-Item 5.15.2\mingw81_64\bin\Qt5Svg.dll -Destination artifactFolder
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: DFTFringe-build-artifact
+          path: |
+            artifactFolder

--- a/DFTFringe.pro
+++ b/DFTFringe.pro
@@ -352,30 +352,30 @@ FORMS    += mainwindow.ui \
 win32 {
       CONFIG( debug, debug|release ) {
         # debug
-        LIBS += D:\\qwt-6.1.5\\lib\\qwtd.dll
+        LIBS += ..\\qwt-6.1.6\\lib\\qwtd.dll
       } else {
         # release
-        LIBS += D:\\qwt-6.1.5\\lib\\qwt.dll
+        LIBS += ..\\qwt-6.1.6\\lib\\qwt.dll
       }
-      INCLUDEPATH += D:\\qwt-6.1.5\\src
+      INCLUDEPATH += ..\\qwt-6.1.6\\src
 
       #message("using win32")include
 
-INCLUDEPATH += D:\armadillo\armadillo-9.200.6\include
+INCLUDEPATH += ..\build_armadillo\tmp\include
 
-INCLUDEPATH += D:\opencv\opencv-3.4.12\build\install\include
+INCLUDEPATH += ..\build_openCV\install\include\
 
-LIBS += D:\opencv\opencv-3.4.12\build\bin\libopencv_core3412.dll
-LIBS += D:\opencv\opencv-3.4.12\build\bin\libopencv_highgui3412.dll
-LIBS += D:\opencv\opencv-3.4.12\build\bin\libopencv_imgcodecs3412.dll
-LIBS += D:\opencv\opencv-3.4.12\build\bin\libopencv_imgproc3412.dll
-LIBS += D:\opencv\opencv-3.4.12\build\bin\libopencv_features2d3412.dll
-LIBS += D:\opencv\opencv-3.4.12\build\bin\libopencv_calib3d3412.dll
+LIBS += ..\build_openCV\install\x64\mingw\bin\libopencv_core460.dll
+LIBS += ..\build_openCV\install\x64\mingw\bin\libopencv_highgui460.dll
+LIBS += ..\build_openCV\install\x64\mingw\bin\libopencv_imgcodecs460.dll
+LIBS += ..\build_openCV\install\x64\mingw\bin\libopencv_imgproc460.dll
+LIBS += ..\build_openCV\install\x64\mingw\bin\libopencv_features2d460.dll
+LIBS += ..\build_openCV\install\x64\mingw\bin\libopencv_calib3d460.dll
 
 
-LIBS += D:\armadillo\bin\libarmadillo.dll
-LIBS += D:\lapack\build64\bin\liblapack.dll
-LIBS += D:\lapack\build64\bin\libblas.dll
+LIBS += ..\build_armadillo\libarmadillo.dll
+LIBS += ..\build_lapack\lib\liblapack.a
+LIBS += ..\build_lapack\lib\libblas.a
 }
 
 

--- a/DFTFringe_Dale.pro
+++ b/DFTFringe_Dale.pro
@@ -1,0 +1,505 @@
+#-------------------------------------------------
+#
+# Project created by QtCreator 2014-08-11T00:35:19
+#
+# Note: This file is to keep historical .pro file of Dale
+# GitHub actions are running on file named DFTFringe.pro
+# Both files will be maintained for an extended transition period
+#
+#-------------------------------------------------
+
+QT += network \
+      xml \
+      multimedia \
+      multimediawidgets \
+      widgets
+QT += concurrent widgets
+QT += charts
+qtHaveModule(printsupport): QT += printsupport
+QT       += core gui
+QT       += opengl widgets
+
+greaterThan(QT_MAJOR_VERSION, 4): QT += widgets
+QT += datavisualization
+TARGET = DFTFringe
+TEMPLATE = app
+
+CONFIG += ``
+
+SOURCES += main.cpp\
+    arbitrarywavefronthelp.cpp \
+    arbitrarywavwidget.cpp \
+    cpoint.cpp \
+    defocusdlg.cpp \
+    edgeplot.cpp \
+    mainwindow.cpp \
+    igramarea.cpp \
+    circleoutline.cpp \
+    gplus.cpp \
+    Boundary.cpp \
+    graphicsutilities.cpp \
+    dfttools.cpp \
+    dftarea.cpp \
+    mikespsirinterface.cpp \
+    oglrendered.cpp \
+    pdfcalibrationdlg.cpp \
+    profileplot.cpp \
+    psiresizeimagesdlg.cpp \
+    surface3dcontrolsdlg.cpp \
+    surfacegraph.cpp \
+    surfacelightingproxy.cpp \
+    userdrawnprofiledlg.cpp \
+    wavefront.cpp \
+    contourplot.cpp \
+    contourtools.cpp \
+    dftcolormap.cpp \
+    surfaceanalysistools.cpp \
+    prefsdlg.cpp \
+    surfacemanager.cpp \
+    zernikedlg.cpp \
+    zernikeprocess.cpp \
+    mirrordlg.cpp \
+    zernikes.cpp \
+    metricsdisplay.cpp \
+    reviewwindow.cpp \
+    wavefrontloader.cpp \
+    rotationdlg.cpp \
+    wftstats.cpp \
+    surfacepropertiesdlg.cpp \
+    imagehisto.cpp \
+    colorchanneldisplay.cpp \
+    intensityplot.cpp \
+    igramintensity.cpp \
+    dftthumb.cpp \
+    vortexdebug.cpp \
+    simigramdlg.cpp \
+    punwrap.cpp \
+    wftexaminer.cpp \
+    savewavedlg.cpp \
+    usercolormapdlg.cpp \
+    colormapviewerdlg.cpp \
+    oglview.cpp \
+    settingsigram.cpp \
+    settings2.cpp \
+    settingsdft.cpp \
+    settingsdebug.cpp \
+    contourview.cpp \
+    simulationsview.cpp \
+    psfplot.cpp \
+    standastigwizard.cpp \
+    counterrotationdlg.cpp \
+    renamewavefrontdlg.cpp \
+    subtractwavefronatsdlg.cpp \
+    helpdlg.cpp \
+    settingsprofile.cpp \
+    batchigramwizard.cpp \
+    outlinehelpdocwidget.cpp \
+    statsview.cpp \
+    jitteroutlinedlg.cpp \
+    nullvariationdlg.cpp \
+    ccswappeddlg.cpp \
+    foucaultview.cpp \
+    squareimage.cpp \
+    bathastigdlg.cpp \
+    zernikeeditdlg.cpp \
+    settingsGeneral2.cpp \
+    nullmarginhelpdlg.cpp \
+    plotcolor.cpp \
+    cameracalibwizard.cpp \
+    camwizardpage1.cpp \
+    camcalibrationreviewdlg.cpp \
+    generatetargetdlg.cpp \
+    lensetablemodel.cpp \
+    unwraperrorsview.cpp \
+    lensdialog.cpp \
+    singleapplication.cpp \
+    messagereceiver.cpp \
+    myutils.cpp \
+    pixelstats.cpp \
+    utilil.cpp \
+    circlefit.cpp \
+    astigstatsdlg.cpp \
+    averagewavefrontfilesdlg.cpp \
+    astigzoomer.cpp \
+    astigscatterplot.cpp \
+    wavefrontfilterdlg.cpp \
+    myplotpicker.cpp \
+    testplotclass.cpp \
+    rmsplot.cpp \
+    regionedittools.cpp \
+    reportdlg.cpp \
+    videosetupdlg.cpp \
+    showaliasdlg.cpp \
+    colorchannel.cpp \
+    wavefrontaveragefilterdlg.cpp \
+    rejectedwavefrontsdlg.cpp \
+    outlinestatsdlg.cpp \
+    filteroutlinesdlg.cpp \
+    outlineplots.cpp \
+    transformwavefrontdlg.cpp \
+    showallcontoursdlg.cpp \
+    psi_dlg.cpp \
+    psiphasedisplay.cpp \
+    outlinedialog.cpp \
+    psitiltoptions.cpp \
+    contourrulerparams.cpp \
+    zernikesmoothingdlg.cpp
+    punwrap.cpp
+
+HEADERS  += mainwindow.h \
+    arbitrarywavefronthelp.h \
+    arbitrarywavwidget.h \
+    bezier.h \
+    cpoint.h \
+    defocusdlg.h \
+    edgeplot.h \
+    IgramArea.h \
+    circleoutline.h \
+    gplus.h \
+    graphicsutilities.h \
+    dfttools.h \
+    dftarea.h \
+    oglrendered.h \
+    pdfcalibrationdlg.h \
+    profileplot.h \
+    psiresizeimagesdlg.h \
+    spline.h \
+    surface3dcontrolsdlg.h \
+    surfacegraph.h \
+    surfacelightingproxy.h \
+    userdrawnprofiledlg.h \
+    wavefront.h \
+    contourplot.h \
+    contourtools.h \
+    dftcolormap.h \
+    surfaceanalysistools.h \
+    prefsdlg.h \
+    surfacemanager.h \
+    zernikedlg.h \
+    zernikeprocess.h \
+    mirrordlg.h \
+    zernikes.h \
+    metricsdisplay.h \
+    reviewwindow.h \
+    vortex.h \
+    wavefrontstats.h \
+    wavefrontloader.h \
+    rotationdlg.h \
+    wftstats.h \
+    surfacepropertiesdlg.h \
+    punwrap.h \
+    imagehisto.h \
+    colorchanneldisplay.h \
+    intensityplot.h \
+    igramintensity.h \
+    dftthumb.h \
+    vortexdebug.h \
+    simigramdlg.h \
+    wftexaminer.h \
+    savewavedlg.h \
+    usercolormapdlg.h \
+    colormapviewerdlg.h \
+    oglview.h \
+    settingsigram.h \
+    settings2.h \
+    settingsdft.h \
+    settingsdebug.h \
+    contourview.h \
+    simulationsview.h \
+    psfplot.h \
+    standastigwizard.h \
+    counterrotationdlg.h \
+    renamewavefrontdlg.h \
+    subtractwavefronatsdlg.h \
+    helpdlg.h \
+    settingsprofile.h \
+    batchigramwizard.h \
+    outlinehelpdocwidget.h \
+    statsview.h \
+    jitteroutlinedlg.h \
+    nullvariationdlg.h \
+    ccswappeddlg.h \
+    foucaultview.h \
+    squareimage.h \
+    bathastigdlg.h \
+    zernikeeditdlg.h \
+    settingsGeneral2.h \
+    nullmarginhelpdlg.h \
+    plotcolor.h \
+    cameracalibwizard.h \
+    camwizardpage1.h \
+    camcalibrationreviewdlg.h \
+    generatetargetdlg.h \
+    lensetablemodel.h \
+    unwraperrorsview.h \
+    lensdialog.h \
+    singleapplication.h \
+    singleapplication_p.h \
+    messagereceiver.h \
+    boundary.h \
+    myutils.h \
+    pixelstats.h \
+    utils.h \
+    circleutils.h \
+    circle.h \
+    astigstatsdlg.h \
+    averagewavefrontfilesdlg.h \
+    astigzoomer.h \
+    astigscatterplot.h \
+    wavefrontfilterdlg.h \
+    myplotpicker.h \
+    testplotclass.h \
+    rmsplot.h \
+    regionedittools.h \
+    reportdlg.h \
+    videosetupdlg.h \
+    showaliasdlg.h \
+    colorchannel.h \
+    wavefrontaveragefilterdlg.h \
+    rejectedwavefrontsdlg.h \
+    outlinestatsdlg.h \
+    filteroutlinesdlg.h \
+    outlineplots.h \
+    transformwavefrontdlg.h \
+    showallcontoursdlg.h \
+    psi_dlg.h \
+    psiphasedisplay.h \
+    outlinedialog.h \
+    mikespsiinterface.h \
+    psitiltoptions.h \
+    contourrulerparams.h \
+    zernikesmoothingdlg.h
+FORMS    += mainwindow.ui \
+    arbitrarywavefronthelp.ui \
+    defocusdlg.ui \
+    dfttools.ui \
+    dftarea.ui \
+    edgeplot.ui \
+    oglrendered.ui \
+    pdfcalibrationdlg.ui \
+    profilearea.ui \
+    profileplot.ui \
+    contourtools.ui \
+    psiresizeimagesdlg.ui \
+    surface3dcontrolsdlg.ui \
+    surfaceanalysistools.ui \
+    prefsdlg.ui \
+    metricsdisplay.ui \
+    userdrawnprofiledlg.ui \
+    zernikedlg.ui \
+    mirrordlg.ui \
+    wavefrontnulldlg.ui \
+    reviewwindow.ui \
+    rotationdlg.ui \
+    surfacepropertiesdlg.ui \
+    colorchanneldisplay.ui \
+    igramintensity.ui \
+    dftthumb.ui \
+    vortexdebug.ui \
+    simigramdlg.ui \
+    wftexaminer.ui \
+    savewavedlg.ui \
+    usercolormapdlg.ui \
+    colormapviewerdlg.ui \
+    settingsigram.ui \
+    settings2.ui \
+    settingsdft.ui \
+    settingsdebug.ui \
+    contourview.ui \
+    simulationsview.ui \
+    psfplot.ui \
+    standastigwizard.ui \
+    counterrotationdlg.ui \
+    renamewavefrontdlg.ui \
+    subtractwavefronatsdlg.ui \
+    helpdlg.ui \
+    settingsprofile.ui \
+    batchigramwizard.ui \
+    outlinehelpdocwidget.ui \
+    statsview.ui \
+    jitteroutlinedlg.ui \
+    nullvariationdlg.ui \
+    ccswappeddlg.ui \
+    foucaultview.ui \
+    bathastigdlg.ui \
+    zernikeeditdlg.ui \
+    settingsGeneral2.ui \
+    nullmarginhelpdlg.ui \
+    cameracalibwizard.ui \
+    camwizardpage1.ui \
+    camcalibrationreviewdlg.ui \
+    generatetargetdlg.ui \
+    unwraperrorsview.ui \
+    lensdialog.ui \
+    pixelstats.ui \
+    astigstatsdlg.ui \
+    averagewavefrontfilesdlg.ui \
+    wavefrontfilterdlg.ui \
+    regionedittools.ui \
+    reportdlg.ui \
+    videosetupdlg.ui \
+    showaliasdlg.ui \
+    wavefrontaveragefilterdlg.ui \
+    rejectedwavefrontsdlg.ui \
+    outlinestatsdlg.ui \
+    filteroutlinesdlg.ui \
+    outlineplots.ui \
+    transformwavefrontdlg.ui \
+    showallcontoursdlg.ui \
+    psi_dlg.ui \
+    psiphasedisplay.ui \
+    outlinedialog.ui \
+    psitiltoptions.ui \
+    contourrulerparams.ui \
+    zernikesmoothingdlg.ui
+
+win32 {
+      CONFIG( debug, debug|release ) {
+        # debug
+        LIBS += D:\\qwt-6.1.5\\lib\\qwtd.dll
+      } else {
+        # release
+        LIBS += D:\\qwt-6.1.5\\lib\\qwt.dll
+      }
+      INCLUDEPATH += D:\\qwt-6.1.5\\src
+
+      #message("using win32")include
+
+INCLUDEPATH += D:\armadillo\armadillo-9.200.6\include
+
+INCLUDEPATH += D:\opencv\opencv-3.4.12\build\install\include
+
+LIBS += D:\opencv\opencv-3.4.12\build\bin\libopencv_core3412.dll
+LIBS += D:\opencv\opencv-3.4.12\build\bin\libopencv_highgui3412.dll
+LIBS += D:\opencv\opencv-3.4.12\build\bin\libopencv_imgcodecs3412.dll
+LIBS += D:\opencv\opencv-3.4.12\build\bin\libopencv_imgproc3412.dll
+LIBS += D:\opencv\opencv-3.4.12\build\bin\libopencv_features2d3412.dll
+LIBS += D:\opencv\opencv-3.4.12\build\bin\libopencv_calib3d3412.dll
+
+
+LIBS += D:\armadillo\bin\libarmadillo.dll
+LIBS += D:\lapack\build64\bin\liblapack.dll
+LIBS += D:\lapack\build64\bin\libblas.dll
+}
+
+
+
+unix {
+     INCLUDEPATH += /usr/include/qwt
+     INCLUDEPATH += /usr/include/opencv4
+     LIBS += -lqwt-qt5
+     LIBS += -lopencv_core
+     LIBS += -lopencv_imgproc
+     LIBS += -lopencv_highgui
+     LIBS += -lGLU
+     LIBS += -lopencv_calib3d
+     LIBS += -lopencv_features2d
+     LIBS += -lopencv_imgproc
+     LIBS += -lopencv_imgcodecs
+     LIBS += -larmadillo
+     message("using linux")
+     contains(CONFIG,debug) { message("no extra debug libraries") }
+}
+
+OTHER_FILES += \
+    todo.txt
+
+RESOURCES += \
+    DFTResources.qrc
+RC_FILE = DFTFringe.rc
+QMAKE_CXXFLAGS += -std=c++11
+
+# The application version
+VERSION = 6.2
+
+# Define the preprocessor macro to get the application version in our application.
+DEFINES += APP_VERSION=\\\"$$VERSION\\\"
+
+DISTFILES += \
+    buildingDFTFringe64.txt \
+    helptext.txt \
+    ColorMaps/Diverging_BrBG.cmp \
+    ColorMaps/Diverging_bwr.cmp \
+    ColorMaps/Diverging_coolwarm.cmp \
+    ColorMaps/Diverging_PiYG.cmp \
+    ColorMaps/Diverging_PRGn.cmp \
+    ColorMaps/Diverging_PuOr.cmp \
+    ColorMaps/Diverging_RdBu.cmp \
+    ColorMaps/Diverging_RdGy.cmp \
+    ColorMaps/Diverging_RdYlBu.cmp \
+    ColorMaps/Diverging_RdYlGn.cmp \
+    ColorMaps/Diverging_seismic.cmp \
+    ColorMaps/Diverging_Spectral.cmp \
+    ColorMaps/Miscellaneous_brg.cmp \
+    ColorMaps/Miscellaneous_CMRmap.cmp \
+    ColorMaps/Miscellaneous_cubehelix.cmp \
+    ColorMaps/Miscellaneous_flag.cmp \
+    ColorMaps/Miscellaneous_gist_earth.cmp \
+    ColorMaps/Miscellaneous_gist_ncar.cmp \
+    ColorMaps/Miscellaneous_gist_rainbow.cmp \
+    ColorMaps/Miscellaneous_gist_stern.cmp \
+    ColorMaps/Miscellaneous_gnuplot.cmp \
+    ColorMaps/Miscellaneous_gnuplot2.cmp \
+    ColorMaps/Miscellaneous_hsv.cmp \
+    ColorMaps/Miscellaneous_jet.cmp \
+    ColorMaps/Miscellaneous_nipy_spectral.cmp \
+    ColorMaps/Miscellaneous_ocean.cmp \
+    ColorMaps/Miscellaneous_prism.cmp \
+    ColorMaps/Miscellaneous_rainbow.cmp \
+    ColorMaps/Miscellaneous_terrain.cmp \
+    ColorMaps/Perceptually Uniform Sequential_inferno.cmp \
+    ColorMaps/Perceptually Uniform Sequential_magma.cmp \
+    ColorMaps/Perceptually Uniform Sequential_plasma.cmp \
+    ColorMaps/Perceptually Uniform Sequential_viridis.cmp \
+    ColorMaps/Qualitative_Accent.cmp \
+    ColorMaps/Qualitative_Dark2.cmp \
+    ColorMaps/Qualitative_Paired.cmp \
+    ColorMaps/Qualitative_Pastel1.cmp \
+    ColorMaps/Qualitative_Pastel2.cmp \
+    ColorMaps/Qualitative_Set1.cmp \
+    ColorMaps/Qualitative_Set2.cmp \
+    ColorMaps/Qualitative_Set3.cmp \
+    ColorMaps/Sequential (2)_afmhot.cmp \
+    ColorMaps/Sequential (2)_autumn.cmp \
+    ColorMaps/Sequential (2)_bone.cmp \
+    ColorMaps/Sequential (2)_cool.cmp \
+    ColorMaps/Sequential (2)_copper.cmp \
+    ColorMaps/Sequential (2)_gist_heat.cmp \
+    ColorMaps/Sequential (2)_gray.cmp \
+    ColorMaps/Sequential (2)_hot.cmp \
+    ColorMaps/Sequential (2)_pink.cmp \
+    ColorMaps/Sequential (2)_spring.cmp \
+    ColorMaps/Sequential (2)_summer.cmp \
+    ColorMaps/Sequential (2)_winter.cmp \
+    ColorMaps/Sequential_Blues.cmp \
+    ColorMaps/Sequential_BuGn.cmp \
+    ColorMaps/Sequential_BuPu.cmp \
+    ColorMaps/Sequential_GnBu.cmp \
+    ColorMaps/Sequential_Greens.cmp \
+    ColorMaps/Sequential_Greys.cmp \
+    ColorMaps/Sequential_Oranges.cmp \
+    ColorMaps/Sequential_OrRd.cmp \
+    ColorMaps/Sequential_PuBu.cmp \
+    ColorMaps/Sequential_PuBuGn.cmp \
+    ColorMaps/Sequential_PuRd.cmp \
+    ColorMaps/Sequential_Purples.cmp \
+    ColorMaps/Sequential_RdPu.cmp \
+    ColorMaps/Sequential_Reds.cmp \
+    ColorMaps/Sequential_YlGn.cmp \
+    ColorMaps/Sequential_YlGnBu.cmp \
+    ColorMaps/Sequential_YlOrBr.cmp \
+    ColorMaps/Sequential_YlOrRd.cmp \
+    ColorMaps/spring.cmp \
+    COPYING.LESSER.txt \
+    COPYING.txt \
+    RevisionHistory.html \
+    README.md \
+
+
+    TRANSLATIONS    = dftfringe_fr.ts
+
+
+
+
+INCLUDEPATH += $$PWD/../../../../opencv/build-mingw/include
+DEPENDPATH += $$PWD/../../../../opencv/build-mingw/include


### PR DESCRIPTION
I'm proud to announce this implements CI to build Windows version of DFTFringe. 
First build will take over 1h because of OpenCV build but every next build will use cache I setup and take under 10 minutes. Cache lives for 7 days.

You will notice I moved openCV 3.4.12 to 4.6.0. I think it is good practice to keep up to date to limit work and help maintenance. And I have not been able to build 3.4.12 anyway so there is no real question here. 4.7.0 breaks build but I might fix later.
I also made relative path for all dependencies in .pro. Maybe we have an other solution but this was easiest for me to make the CI work. Sorry Dale, you will either need to accommodate the path I propose or we set so env var or something to accommodate everybody. I'm open to discussion (chat or call).

I don't know why lapack and blas are .a instead .dll on my build, maybe we can fix that later.

You will be able to download a zip of build result exe and dll in action tab under artifacts. It's named `DFTFringe-build-artifact`. here is an example of the build at the moment of this PR: https://github.com/atsju/DFTFringe/actions/runs/4246078248
Once mergged, actions will run in DFTFringe organisation instead my atsju organisation.
Artifacts live for 90 days. It does not replace releases but will help Dale and others test the proposals without rebuilding himself.

@githubdoe If you write a simple but complete document about creating the installer I could add the step to the build so that the artifact is an actual installer instead the exe that won't work on it's own on a clean computer.

I keep this PR draft for now because I would like the other PRs to be merged before so I can rebase the branch properly.
I also expect to have some discussion here. 

This has already been a lot of work but I have a some improvements in mind. Maybe I should list them is an issue ?

Notify @githubdoe @gr5 @brave-ulysses 