### PR TITLE
Releases are automatically drafted from semver tags

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -5,6 +5,7 @@ on:
       - master
   pull_request:
   workflow_dispatch:
+  workflow_call:
 
 jobs:
   build-linux:

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -295,6 +295,27 @@ jobs:
         with:
           path: 'DFTFringe'
 
+      # Update the 2 strings automatically
+      # MY_AUTOMATED_VERSION_STRING
+      # MY_AUTOMATED_DATE_STRING
+      # TODO must work on tags but also on PR and manual builds (using github.sha ?)
+      - name: Find and Replace MY_AUTOMATED_VERSION_STRING
+        run: |
+          echo "${{github.event_name}}"
+          echo "${{github.ref_name}}"
+          echo "${{github.sha}}"
+          (Get-Content DFTFringe/DFTFringeInstaller/config/config.xml).replace('MY_AUTOMATED_VERSION_STRING', '${{github.ref_name}}') | Set-Content DFTFringe/DFTFringeInstaller/config/config.xml
+          (Get-Content DFTFringe/DFTFringeInstaller/packages/com.githubdoe.DFTFringe/meta/package.xml).replace('MY_AUTOMATED_VERSION_STRING', '${{github.ref_name}}') | Set-Content DFTFringe/DFTFringeInstaller/packages/com.githubdoe.DFTFringe/meta/package.xml
+          (Get-Content DFTFringe/DFTFringe.pro).replace('MY_AUTOMATED_VERSION_STRING', '${{github.ref_name}}') | Set-Content DFTFringe/DFTFringe.pro
+      - name: Put current date into a variable
+        run: |
+          $NOW=& Get-Date -format yyyy-MM-dd
+          echo "NOW=$NOW" >> $env:GITHUB_ENV
+      - name: Find and Replace MY_AUTOMATED_DATE_STRING
+        run: |
+          echo "${{env.NOW}}"
+          (Get-Content DFTFringe/DFTFringeInstaller/packages/com.githubdoe.DFTFringe/meta/package.xml).replace('MY_AUTOMATED_DATE_STRING', '${{env.NOW}}') | Set-Content DFTFringe/DFTFringeInstaller/packages/com.githubdoe.DFTFringe/meta/package.xml
+          
       - run: cd DFTFringe ; ..\5.15.2\mingw81_64\bin\qmake.exe
       - run: cd DFTFringe ; mingw32-make -j4
 
@@ -318,12 +339,11 @@ jobs:
         run: .\5.15.2\mingw81_64\bin\windeployqt.exe DFTFringe\DFTFringeInstaller\packages\com.githubdoe.DFTFringe\data\DFTFringe.exe
 
       - name: make installer using QT installer framework
-        run: Tools\QtInstallerFramework\4.6\bin\binarycreator.exe -c DFTFringe\DFTFringeInstaller\config\config.xml -p DFTFringe\DFTFringeInstaller\packages DFTFringeInstaller
-        #TODO version in name
+        run: Tools\QtInstallerFramework\4.6\bin\binarycreator.exe -c DFTFringe\DFTFringeInstaller\config\config.xml -p DFTFringe\DFTFringeInstaller\packages DFTFringeInstaller_${{github.ref_name}}
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v3
         with:
           name: DFTFringe-windows-build-artifact
           path: |
-            DFTFringeInstaller.exe
+            DFTFringeInstaller_${{github.ref_name}}.exe

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -5,6 +5,7 @@ on:
       - master
   pull_request:
   workflow_dispatch:
+  workflow_call:
 
 jobs:
   cache-mingw-from-QT:
@@ -323,6 +324,6 @@ jobs:
       - name: Upload Artifact
         uses: actions/upload-artifact@v3
         with:
-          name: DFTFringe-build-artifact
+          name: DFTFringe-windows-build-artifact
           path: |
             DFTFringeInstaller.exe

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -298,15 +298,29 @@ jobs:
       # Update the 2 strings automatically
       # MY_AUTOMATED_VERSION_STRING
       # MY_AUTOMATED_DATE_STRING
-      # TODO must work on tags but also on PR and manual builds (using github.sha ?)
+      - name: Put release name into a variable (pull request)
+        if: ${{ github.event_name == 'pull_request' }}
+        # suffix will be c18a74e0f4f4db36eddc66a68eb08e91cd6c6a1c_5108ce7c3ac60bec1e0867bb10c4497db67e3606
+        # Because build is a merge commit, clearly identifies the PR commit and base commit
+        run: |
+          echo "WORKFLOW_VERSION=${{github.event.pull_request.head.sha}}_${{github.event.pull_request.base.sha}}" >> $env:GITHUB_ENV
+      - name: Put release name into a variable (tag)
+        if: ${{ startsWith(github.event.ref, 'refs/tags/v') }}
+        # suffix will be tag like v1.2.3 or v1.0.0-beta+exp.sha.5114f8512 as long as it respects semver
+        run: |
+          echo "WORKFLOW_VERSION=${{github.ref_name}}" >> $env:GITHUB_ENV
+      - name: Put release name into a variable (single commit)
+        if: ${{ !startsWith(github.event.ref, 'refs/tags/v') && github.event_name != 'pull_request'}}
+        # suffix will be commit sha 5108ce7c3ac60bec1e0867bb10c4497db67e3606
+        run: |
+          echo "WORKFLOW_VERSION=${{github.sha}}" >> $env:GITHUB_ENV
+       
       - name: Find and Replace MY_AUTOMATED_VERSION_STRING
         run: |
-          echo "${{github.event_name}}"
-          echo "${{github.ref_name}}"
-          echo "${{github.sha}}"
-          (Get-Content DFTFringe/DFTFringeInstaller/config/config.xml).replace('MY_AUTOMATED_VERSION_STRING', '${{github.ref_name}}') | Set-Content DFTFringe/DFTFringeInstaller/config/config.xml
-          (Get-Content DFTFringe/DFTFringeInstaller/packages/com.githubdoe.DFTFringe/meta/package.xml).replace('MY_AUTOMATED_VERSION_STRING', '${{github.ref_name}}') | Set-Content DFTFringe/DFTFringeInstaller/packages/com.githubdoe.DFTFringe/meta/package.xml
-          (Get-Content DFTFringe/DFTFringe.pro).replace('MY_AUTOMATED_VERSION_STRING', '${{github.ref_name}}') | Set-Content DFTFringe/DFTFringe.pro
+          echo "${{env.WORKFLOW_VERSION}}"
+          (Get-Content DFTFringe/DFTFringeInstaller/config/config.xml).replace('MY_AUTOMATED_VERSION_STRING', '${{env.WORKFLOW_VERSION}}') | Set-Content DFTFringe/DFTFringeInstaller/config/config.xml
+          (Get-Content DFTFringe/DFTFringeInstaller/packages/com.githubdoe.DFTFringe/meta/package.xml).replace('MY_AUTOMATED_VERSION_STRING', '${{env.WORKFLOW_VERSION}}') | Set-Content DFTFringe/DFTFringeInstaller/packages/com.githubdoe.DFTFringe/meta/package.xml
+          (Get-Content DFTFringe/DFTFringe.pro).replace('MY_AUTOMATED_VERSION_STRING', '${{env.WORKFLOW_VERSION}}') | Set-Content DFTFringe/DFTFringe.pro
       - name: Put current date into a variable
         run: |
           $NOW=& Get-Date -format yyyy-MM-dd
@@ -339,11 +353,11 @@ jobs:
         run: .\5.15.2\mingw81_64\bin\windeployqt.exe DFTFringe\DFTFringeInstaller\packages\com.githubdoe.DFTFringe\data\DFTFringe.exe
 
       - name: make installer using QT installer framework
-        run: Tools\QtInstallerFramework\4.6\bin\binarycreator.exe -c DFTFringe\DFTFringeInstaller\config\config.xml -p DFTFringe\DFTFringeInstaller\packages DFTFringeInstaller_${{github.ref_name}}
+        run: Tools\QtInstallerFramework\4.6\bin\binarycreator.exe -c DFTFringe\DFTFringeInstaller\config\config.xml -p DFTFringe\DFTFringeInstaller\packages DFTFringeInstaller_${{env.WORKFLOW_VERSION}}
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v3
         with:
           name: DFTFringe-windows-build-artifact
           path: |
-            DFTFringeInstaller_${{github.ref_name}}.exe
+            DFTFringeInstaller_${{env.WORKFLOW_VERSION}}.exe

--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -53,10 +53,7 @@ jobs:
             - make the actual release from this draft
           # the release will be drafted so it needs to be manually published after release notes editions
           draft: true
-          #generate_release_notes: true // TODO to be investigated to be sure we never forget something
+          # an automated release note is generated based on PRs to master
+          generate_release_notes: true
           files: |
-            DFTFringeInstaller.exe
-
-  # TODO 
-  # modify other actions to take the tag version OR sha depending on caller
-
+            DFTFringeInstaller_${{github.ref_name}}.exe

--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -1,0 +1,62 @@
+name: make-release
+
+on:
+  push:
+    tags:
+      # all tags prefixed with v will trigger this action. Filter out good naming later
+      # github doesn't support regex here but only basic filtering syntax
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  # Check is based on the official semver regex (prefixed with a v for tag name) https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
+  # "v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$"
+  check-semver:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check Tag
+        shell: python
+        run: |
+          import re
+          if re.match("^refs/tags/v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$", "${{ github.event.ref }}"):
+            exit(0)
+          else:
+            print("This tag doesn't match semantic versionning. See https://semver.org/")
+            exit(1)
+
+  # acually build the artifacts that will be uploaded to release
+  call-build-windows:
+    needs: check-semver
+    uses: ./.github/workflows/build-windows.yml
+  # linux build is mainly here to check it builds. We have no acrtifact now.
+  call-build-linux:
+    needs: check-semver
+    uses: ./.github/workflows/build-linux.yml
+
+  download-and-publish-artifacts:
+    runs-on: ubuntu-latest
+    needs: call-build-windows
+    steps:
+      # get artifact uploaded from build workflow
+      - uses: actions/download-artifact@v3
+        with:
+          name: DFTFringe-windows-build-artifact
+      # create the GitHub release and upload the artifacts
+      - name: publish Release
+        uses: softprops/action-gh-release@v1
+        with:
+          body: |
+            - edit this changelog
+            - test the installer one last time
+            - make the actual release from this draft
+          # the release will be drafted so it needs to be manually published after release notes editions
+          draft: true
+          #generate_release_notes: true // TODO to be investigated to be sure we never forget something
+          files: |
+            DFTFringeInstaller.exe
+
+  # TODO 
+  # modify other actions to take the tag version OR sha depending on caller
+

--- a/DFTFringe.pro
+++ b/DFTFringe.pro
@@ -406,7 +406,7 @@ RC_FILE = DFTFringe.rc
 QMAKE_CXXFLAGS += -std=c++11
 
 # The application version
-VERSION = 6.2
+VERSION = MY_AUTOMATED_VERSION_STRING
 
 # Define the preprocessor macro to get the application version in our application.
 DEFINES += APP_VERSION=\\\"$$VERSION\\\"

--- a/DFTFringeInstaller/config/config.xml
+++ b/DFTFringeInstaller/config/config.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Installer>
     <Name>DFTFringe</Name>
-    <Version>a.b.c</Version>
+    <Version>MY_AUTOMATED_VERSION_STRING</Version>
     <Title>DFTFringe Installer</Title>
     <Publisher>githubdoe</Publisher>
     <StartMenuDir>DFTFringe</StartMenuDir>

--- a/DFTFringeInstaller/packages/com.githubdoe.DFTFringe/meta/package.xml
+++ b/DFTFringeInstaller/packages/com.githubdoe.DFTFringe/meta/package.xml
@@ -2,8 +2,8 @@
 <Package>
     <DisplayName>DFTFringe</DisplayName>
     <Description>Install DFTFringe</Description>
-    <Version>a.b.c</Version>
-    <ReleaseDate>2010-01-01</ReleaseDate>
+    <Version>MY_AUTOMATED_VERSION_STRING</Version>
+    <ReleaseDate>MY_AUTOMATED_DATE_STRING</ReleaseDate>
     <Default>true</Default>
     <Script>installscript.qs</Script>
     <UserInterfaces>


### PR DESCRIPTION
### Clearly indentification of the running code:
Following #32, this PR make a a better artifact generation process. Now the artifact has clear ways to be identified. If somebody uses it (end user should only use tagged versions) they can know exactly the version they are installing and/or running.

### (semi-)automated release creation:
This enforces semver convention https://semver.org/ which is industry standard. Next release should be v7.0.0
7.0.0 will not create a release. Neither will 6.3 and v6.3. You need vx.y.z

The process for creating a new release is highly simplified. 

1. push a new tag respecting senver format (`git tag v7.0.0` `git push --tags`)
2. wait for workflow to finish. You now have a DRAFT release available on release page (everything has been generated and uploaded automatically)
![image](https://github.com/githubdoe/DFTFringe/assets/4628382/fc115406-da7d-4229-abcc-0801bd88b98b)
3. re-test the installer to check everything is fine
4. change the text in release at your convenance (list of changes are automatically generated so you forget nothing)
5. publish the release

### here are some example of what we see:
PR build generates : DFTFringeInstaller_60c45320dcb2a2a792da264ef6b7b797ce3eee59_c18a74e0f4f4db36eddc66a68eb08e91cd6c6a1c.exe
![image](https://github.com/githubdoe/DFTFringe/assets/4628382/2cbc9f36-e569-49ab-8e45-80f1a0ab19e1)

Merge to master or push to master or manual run will generate:
DFTFringeInstaller_baa81492b15f4ab6ddf39689cb75cfac7a99a888.exe 
![image](https://github.com/githubdoe/DFTFringe/assets/4628382/7dcb8766-3b24-470f-a8f1-ceeed31ec03c)

Pushing a tag will generate:
DFTFringeInstaller_v7.1.2.exe
![image](https://github.com/githubdoe/DFTFringe/assets/4628382/9bc6f76b-3e69-40e1-85b6-10fc7eace8dc)
