### PR TITLE
fix deprection warnings

### DIFF
--- a/astigstatsdlg.cpp
+++ b/astigstatsdlg.cpp
@@ -118,7 +118,7 @@ astigStatsDlg::astigStatsDlg(QVector<wavefront *> wavefronts, QWidget *parent) :
         QStringList items;
         items << name;
         for (int z = 0; z < Z_TERMS; ++z){
-            items << QString().sprintf("%6.5lf",m_wavefronts[i]->InputZerns[z]);
+            items << QString("%1").arg(m_wavefronts[i]->InputZerns[z], 6,'f',5);
         }
         m_zerns << items;
     }
@@ -298,7 +298,7 @@ void astigStatsDlg::plot(){
         double rad = sqrt(xstd * xstd + ystd * ystd);
         if (!ui->onlyAverages->isChecked()){
             QwtPlotCurve *curve = new QwtPlotCurve(name.replace(".wft","") +
-                             QString().sprintf("\n%6.4lf,%6.4lf \nSD: %6.4lf %6.4lf ",xmean, ymean, xstd,ystd));
+                             QString("\n%1,%2 \nSD: %3 %4 ").arg(xmean, 6,'f',4).arg(ymean, 6,'f',4).arg(xstd, 6,'f',4).arg(ystd, 6,'f',4));
             curve->setSamples(points);
             curve->setStyle(QwtPlotCurve::Dots);
             curve->setPen(color,10);
@@ -316,7 +316,7 @@ void astigStatsDlg::plot(){
         meanm->setValue(xmean,ymean);
         meanm->setSymbol(new QwtSymbol(QwtSymbol::Ellipse, color,color, QSize(10,10)));
         QStringList paths = name.split("/");
-        meanm->setTitle(paths[paths.size()-1].replace(".wft","")+ " " + QString().sprintf("\n%6.4lf,%6.4lf",xmean, ymean));
+        meanm->setTitle(paths[paths.size()-1].replace(".wft","")+ " " + QString("\n%1,%2").arg(xmean, 6,'f',4).arg(ymean, 6,'f',4));
         meanm->setLabel(paths[paths.size()-1].replace(".wft",""));
         meanm->setLabelAlignment(Qt::AlignBottom);
         meanm->setItemAttribute(QwtPlotItem::Legend, false);
@@ -327,7 +327,7 @@ void astigStatsDlg::plot(){
 
 
             QPolygonF Circle;
-            QString sd= QString().sprintf("SD %6.4lf",rad);
+            QString sd= QString("SD %1").arg(rad, 6,'f',4);
             QwtPlotCurve *circleCv = new QwtPlotCurve();
             for (double rho = 0; rho <= 2 * M_PI; rho += M_PI/32.){
                 Circle << QPointF(xmean + rad* cos(rho), ymean + rad * sin(rho));
@@ -425,7 +425,7 @@ void astigStatsDlg::plot(){
 
         QPolygonF Circle;
 
-        QwtPlotCurve *circleCv = new QwtPlotCurve(QString().sprintf("Best Fit astig mag %6.5lf",c.r));
+        QwtPlotCurve *circleCv = new QwtPlotCurve(QString("Best Fit astig mag %1").arg(c.r, 6,'f',5));
         for (double rho = 0; rho <= 2 * M_PI; rho += M_PI/32.){
             Circle << QPointF(c.a + c.r* cos(rho), c.b +c.r * sin(rho));
         }
@@ -449,7 +449,7 @@ void astigStatsDlg::plot(){
     else {
         ui->bestFitCB->hide();
     }
-    ui->mPlot->setTitle(QString().sprintf("Summary of %d samples", m_zerns.size()));
+    ui->mPlot->setTitle(QString("Summary of %1 samples").arg(m_zerns.size()));
     zoomer->setZoomBase();
 
     ui->mPlot->replot();

--- a/averagewavefrontfilesdlg.cpp
+++ b/averagewavefrontfilesdlg.cpp
@@ -70,7 +70,7 @@ void averageWaveFrontFilesDlg::on_process_clicked()
             double stdVal = std.val[0]* md->lambda/outputLambda;
             if (stdVal > filterRMS){
                 QFileInfo info(name);
-                QString item = QString().sprintf("%s RMS:%lf", info.baseName().toStdString().c_str(), stdVal);
+                QString item = QString("%1 RMS:%2").arg(info.baseName().toStdString().c_str()).arg(stdVal, 0, 'f');
                 rejects << item;
                 ui->fileList->item(i)->setForeground(Qt::red);
                 qApp->processEvents();

--- a/averagewavefrontfilesdlg.cpp
+++ b/averagewavefrontfilesdlg.cpp
@@ -70,7 +70,7 @@ void averageWaveFrontFilesDlg::on_process_clicked()
             double stdVal = std.val[0]* md->lambda/outputLambda;
             if (stdVal > filterRMS){
                 QFileInfo info(name);
-                QString item = QString("%1 RMS:%2").arg(info.baseName().toStdString().c_str()).arg(stdVal, 0, 'f');
+                QString item = QString("%1 RMS:%2").arg(info.baseName()).arg(stdVal, 0, 'f');
                 rejects << item;
                 ui->fileList->item(i)->setForeground(Qt::red);
                 qApp->processEvents();

--- a/camwizardpage1.cpp
+++ b/camwizardpage1.cpp
@@ -171,12 +171,12 @@ bool CamWizardPage1::runCalibrationAndSave(cv::Size imageSize, cv::Mat&  cameraM
     bool ok = runCalibration(imageSize, cameraMatrix, distCoeffs, imagePoints, rvecs, tvecs,
                              reprojErrs, totalAvgErr);
     if (!ok){
-        QString msg = QString().sprintf("Calibration failed. avg re projection error = %lf", totalAvgErr);
+        QString msg = QString("Calibration failed. avg re projection error = %1").arg(totalAvgErr, 0, 'f');
 
        QMessageBox::warning(0,"warning", msg);
        return !ok;
     }
-    ui->Results->append(QString().sprintf("total average error %lf\n",totalAvgErr));
+    ui->Results->append(QString("total average error %1\n").arg(totalAvgErr, 0, 'f'));
     ui->Results->append(ok ? QString("Calibration succeeded") : QString("Calibration failed"));
 
     return ok;
@@ -280,7 +280,7 @@ void CamWizardPage1::on_compute_clicked()
                 sizex.width = size.width + deltas[i].width;
                 sizex.height = size.height +  deltas[i].height;
 
-                ui->Results->append(QString().sprintf("trying %dX%d", sizex.width,sizex.height));
+                ui->Results->append(QString("trying %1X%2").arg(sizex.width).arg(sizex.height));
                 qApp->processEvents();
                 pointBuf.clear();
                 found = cv::findChessboardCorners( viewGray.clone(), sizex, pointBuf,

--- a/contourplot.cpp
+++ b/contourplot.cpp
@@ -65,7 +65,7 @@ public:
             return QwtText("");
         if (pos.x() == lastx && pos.y() == lasty){
                     double v = thePlot->d_spectrogram->data()->value(pos.x(),pos.y());
-          QString t =  QString().sprintf("%lf", v);
+          QString t =  QString("%1").arg(v, 0, 'f');
 
           QwtText label(t);
 
@@ -91,7 +91,7 @@ public:
         //double angle = atan2(dely,delx);
         double R = sqrt( delx * delx + dely * dely )/thePlot->m_wf->data.rows;
         double r = R * thePlot->m_wf->diameter;
-        QwtText text(QString().sprintf("%lf R:%3.2lfmm",v, r));
+        QwtText text(QString("%1 R:%2mm").arg(v, 0, 'f').arg(r, 3, 'f', 2));
         text.setFont(QFont("Arial",12));
         text.setBackgroundBrush( QBrush( bg ) );
         thePlot->selected(pos);
@@ -409,7 +409,7 @@ void ContourPlot::setSurface(wavefront * wf) {
 
     setZRange();
     QwtScaleWidget *rightAxis = axisWidget( QwtPlot::yRight );
-    rightAxis->setTitle( QString().sprintf("wavefront error at %6.2lf nm", outputLambda) );
+    rightAxis->setTitle( QString("wavefront error at %1 nm").arg(outputLambda, 6, 'f', 2) );
     rightAxis->setColorBarEnabled( true );
     rightAxis->setColorBarWidth(30);
     if (!m_minimal){
@@ -431,7 +431,7 @@ void ContourPlot::setSurface(wavefront * wf) {
         name = wf->name;
     name = name.replace(".wft","");
 
-    setFooter(name + QString().sprintf(" %6.3lf rms %d X %d",wf->std, wf->data.cols, wf->data.rows));
+    setFooter(name + QString(" %1 rms %2 X %3").arg(wf->std, 6, 'f', 3).arg(wf->data.cols).arg(wf->data.rows));
 
     plotLayout()->setAlignCanvasToScales(true);
     showContoursChanged(contourRange);

--- a/counterrotationdlg.cpp
+++ b/counterrotationdlg.cpp
@@ -24,7 +24,7 @@ CounterRotationDlg::CounterRotationDlg(QString fn, double rot, bool dir, QWidget
 {
     ui->setupUi(this);
     ui->fileName->setText(fn);
-    ui->counterRotation->setText(QString().sprintf("%6.1lf", rot));
+    ui->counterRotation->setText(QString("%1").arg(rot, 6, 'f', 1));
     ui->CW->setChecked(dir);
 }
 QString CounterRotationDlg::getRotation(){

--- a/defocusdlg.cpp
+++ b/defocusdlg.cpp
@@ -63,7 +63,7 @@ void defocusDlg::on_defocusSlider_valueChanged(int value)
     double f = mirrorDlg::get_Instance()->FNumber;
     double mm = f * f * 8. * value * .00055;  //mmeters
     qDebug() << "mm" << mm;
-    ui->Focusoffset->setText(QString().sprintf("%6.3lfmm", mm));
+    ui->Focusoffset->setText(QString("%1mm").arg(mm, 6,'f',3));
 }
 
 

--- a/dftarea.cpp
+++ b/dftarea.cpp
@@ -1217,7 +1217,7 @@ cv::Mat DFTArea::PSILoadFullImages(){
         }
         else {
             if ((datam.cols != m_psiCols) || (datam.rows != m_psiRows)){
-                QString msg = QString("igram %1 (%2,%3)is not the same size as %4 (%5,%6)").arg(m_psiFiles[cnt].toStdString().c_str()).arg(datam.rows).arg(datam.cols).arg( m_psiFiles[0].toStdString().c_str()).arg(m_psiRows).arg(m_psiCols);
+                QString msg = QString("igram %1 (%2,%3)is not the same size as %4 (%5,%6)").arg(m_psiFiles[cnt]).arg(datam.rows).arg(datam.cols).arg(m_psiFiles[0]).arg(m_psiRows).arg(m_psiCols);
                 QMessageBox::warning(0, "Failed", msg);
                  QApplication::restoreOverrideCursor();
                  return data;

--- a/dftarea.cpp
+++ b/dftarea.cpp
@@ -344,10 +344,10 @@ cv::Mat DFTArea::grayComplexMatfromImage(QImage &img){
     Mat  complexI;
     merge(planes, 2, complexI);         // Add to the expanded another plane with zeros
     if (scaleFactor == 1.){
-        tools->imageSize(QString().sprintf("DFT Size will be %d", width));
+        tools->imageSize(QString("DFT Size will be %1").arg(width));
     }
     else
-        tools->imageSize(QString().sprintf("Image is resized from %d to %d pixels",width, complexI.cols));
+        tools->imageSize(QString("Image is resized from %1 to %2 pixels").arg(width).arg(complexI.cols));
     return complexI;
 }
 
@@ -919,19 +919,19 @@ cv::Mat DFTArea::vortex(QImage &img, double low)
     }
     catch (std::bad_alloc &e){
         showmem();
-        qDebug() << QString().sprintf("Error %s", e.what());
+        qDebug() << QString("Error %1").arg(e.what());
        //cv::Mat phase = cv::Mat::zeros(Size(100,100), numType);
 
        return cv::Mat();
     }
     catch ( std::exception &e){
 
-        qDebug() << QString().sprintf(" some Error %s", e.what());
+        qDebug() << QString(" some Error %1").arg(e.what());
        cv::Mat phase = cv::Mat::zeros(Size(0,0), numType);
        return phase;
     }
     catch (...){
-        qDebug() << QString().sprintf(" Unknown error ");
+        qDebug() << QString(" Unknown error ");
        cv::Mat phase = cv::Mat::zeros(Size(100,100), numType);
        return phase;
     }
@@ -1114,7 +1114,7 @@ void dumpMat(cv::Mat m, QString title = ""){
     for (int r = 0; r < m.rows; ++r){
         QString msg;
         for (int c = 0; c < m.cols; ++c){
-          msg = msg + QString().sprintf("% 6.2e",m.at<double>(r,c)) + " ";
+          msg = msg + QString("%1 ").arg(m.at<double>(r,c), 6, 'e', 2);
           if ( c > 8){
               msg = msg + "...";
               break;
@@ -1188,7 +1188,7 @@ cv::Mat DFTArea::PSILoadFullImages(){
         QApplication::processEvents();
         QImage loadedImage;
         if (!loadedImage.load(name)){
-            QString msg =  QString().sprintf("Failed to load %s",name.toStdString().c_str());
+            QString msg = QString("Failed to load %1").arg(name);
             QMessageBox::warning(0, "load image failed", msg);
             continue;
         }
@@ -1217,9 +1217,7 @@ cv::Mat DFTArea::PSILoadFullImages(){
         }
         else {
             if ((datam.cols != m_psiCols) || (datam.rows != m_psiRows)){
-                QString msg = QString().sprintf("igram %s (%d,%d)is not the same size as %s (%d,%d)",
-                  m_psiFiles[cnt].toStdString().c_str(),datam.rows,datam.cols, m_psiFiles[0].toStdString().c_str(),
-                        m_psiRows,m_psiCols);
+                QString msg = QString("igram %1 (%2,%3)is not the same size as %4 (%5,%6)").arg(m_psiFiles[cnt].toStdString().c_str()).arg(datam.rows).arg(datam.cols).arg( m_psiFiles[0].toStdString().c_str()).arg(m_psiRows).arg(m_psiCols);
                 QMessageBox::warning(0, "Failed", msg);
                  QApplication::restoreOverrideCursor();
                  return data;
@@ -1609,17 +1607,16 @@ QVector<double> DFTArea::getPhases(){
         m_Psidlg->setPhases(a);
         m_Psidlg->plot(a, i, sdp);
         // repeat until convergence
-        m_Psidlg->setStatusText(QString().sprintf("iteration %d  sdp %lf", i, sdp),i);
+        m_Psidlg->setStatusText(QString("iteration %1  sdp %2").arg(i).arg(sdp, 0, 'f'),i);
         if (i > 1 && (sdp < ptol)) {
 
             break;
         }
         phases_last = phases;
-        emit statusBarUpdate(QString().sprintf("%d %lf",i, sdp),2);
+        emit statusBarUpdate(QString("%1 %2").arg(i).arg(sdp, 0, 'f'),2);
     }
     if (i == maxiter && (sdp > ptol)){
-        QString msg = QString().sprintf("The calculated phases did not converge within the maximum number"
-                             " of iterations (%d). \nThey proabably are not valid.",maxiter);
+        QString msg = QString("The calculated phases did not converge within the maximum number of iterations (%1). \nThey proabably are not valid.").arg(maxiter);
         QMessageBox::warning(0, "No convegence", msg );
         phases = trials[bestIteration];
         i = bestIteration;
@@ -1634,7 +1631,7 @@ QVector<double> DFTArea::getPhases(){
     for (int i = 0; i < phases.n_cols; ++i){
         a << phases(i);
     }
-    m_Psidlg->setStatusText(QString().sprintf("iteration %d  sdp %lf Compute Phases complete. ", i, sdp),maxiter);
+    m_Psidlg->setStatusText(QString("iteration %1  sdp %2 Compute Phases complete. ").arg(i).arg(sdp, 0, 'f'),maxiter);
 
     return a;
 }

--- a/foucaultview.cpp
+++ b/foucaultview.cpp
@@ -54,7 +54,7 @@ QString getSaveFileName(QString type){
     QString path = settings.value("lastPath","").toString();
 
     QString fileName = QFileDialog::getSaveFileName(0,
-            QString("File name of %1 image to be saved").arg(type.toStdString().c_str()),
+            QString("File name of %1 image to be saved").arg(type),
                                                  path);
 
     if (!fileName.endsWith(".jpg"))
@@ -536,7 +536,7 @@ void foucaultView::on_scanPb_clicked()
         if (ui->SaveImageCB->isChecked()){
             QString num = QString("%1").arg(v, 6, 'f', 4).replace(".","_");
             num.replace("-","n");
-            QString fvpng = QString("%1//%2_%3.png").arg(imageDir.toStdString().c_str()).arg(cnt++, 6, 10, QLatin1Char('0')).arg(num.toStdString().c_str());
+            QString fvpng = QString("%1//%2_%3.png").arg(imageDir).arg(cnt++, 6, 10, QLatin1Char('0')).arg(num);
             qDebug() << "fn"<< fvpng;
             if (ui->saveOnlyFouccault->isChecked()){
                 fv->m_foucultQimage.save(fvpng);

--- a/foucaultview.cpp
+++ b/foucaultview.cpp
@@ -54,7 +54,7 @@ QString getSaveFileName(QString type){
     QString path = settings.value("lastPath","").toString();
 
     QString fileName = QFileDialog::getSaveFileName(0,
-            QString().sprintf("File name of %d image to be saved", type.toStdString().c_str()),
+            QString("File name of %1 image to be saved").arg(type.toStdString().c_str()),
                                                  path);
 
     if (!fileName.endsWith(".jpg"))
@@ -243,11 +243,11 @@ void foucaultView::on_makePb_clicked()
 
     double slitWidthHalf = pixels_per_thou * ui->slitWidthSb->value() * 1000 * ((ui->useMM->isChecked()) ? 1./25.4 : 1.);
     if (slitWidthHalf < .75){
-        QString msg = QString().sprintf("warning the slit width of %6.5lf may too small. Using one pixel slit instead", ui->slitWidthSb->value());
+        QString msg = QString("warning the slit width of %1 may too small. Using one pixel slit instead").arg(ui->slitWidthSb->value(), 6, 'f', 5);
         QMessageBox::warning(0,"warning", msg);
 
     }
-    QString parms = QString().sprintf(" Pixel width %6.5lf slit size in pixels %d", pixwidth, (int)(2 * slitWidthHalf));
+    QString parms = QString(" Pixel width %1 slit size in pixels %2").arg(pixwidth, 6, 'f', 5).arg((int)(2 * slitWidthHalf));
     ui->pixeParms->setText(parms);
     // compute offset so that line is at center
     for (int y = 0; y < size; ++y)
@@ -339,8 +339,8 @@ void foucaultView::on_makePb_clicked()
     painter.drawPixmap(0, 0, rp);
     painter.setPen(QPen(QColor(Qt::white)));
     painter.setFont(QFont("Arial", 15));
-    QString zoffsetStr = QString().sprintf("%6.3lf %s", ui->RonchiX->value() * ui->rocOffsetSb->value(),
-                                           ui->useMM->isChecked()? "mm" : "in");
+    QString zoffsetStr = QString("%1 %2").arg(ui->RonchiX->value() * ui->rocOffsetSb->value(), 6, 'f', 3)
+                                           .arg(ui->useMM->isChecked()? "mm" : "in");
     painter.drawText(20, 40, zoffsetStr);
     QVector<QPoint> profilePoints;
     if (ui->overlayProfile->isChecked()){
@@ -397,8 +397,8 @@ void foucaultView::on_makePb_clicked()
     painterf.drawPixmap(0, 0, rpf);
     painterf.setPen(QPen(QColor(Qt::white)));
     painterf.setFont(QFont("Arial", 15));
-    zoffsetStr = QString().sprintf("%6.3lf %s", ui->rocOffsetSb->value(),
-                                   ui->useMM->isChecked()? "mm" : "in");
+    zoffsetStr = QString("%1 %2").arg(ui->rocOffsetSb->value(), 6 , 'f', 3)
+                                   .arg(ui->useMM->isChecked()? "mm" : "in");
     painterf.drawText(20, 40, zoffsetStr);
     if (ui->overlayProfile->isChecked()){
         // overlay profile onto ronchi plot
@@ -534,9 +534,9 @@ void foucaultView::on_scanPb_clicked()
         QPainter p3(&fvImage);
         fv->QWidget::render(&p3);
         if (ui->SaveImageCB->isChecked()){
-            QString num = QString().sprintf("%6.4lf",v).replace(".","_");
+            QString num = QString("%1").arg(v, 6, 'f', 4).replace(".","_");
             num.replace("-","n");
-            QString fvpng = QString().sprintf("%s//%06d_%s.png",imageDir.toStdString().c_str(), cnt++, num.toStdString().c_str());
+            QString fvpng = QString("%1//%2_%3.png").arg(imageDir.toStdString().c_str()).arg(cnt++, 6, 10, QLatin1Char('0')).arg(num.toStdString().c_str());
             qDebug() << "fn"<< fvpng;
             if (ui->saveOnlyFouccault->isChecked()){
                 fv->m_foucultQimage.save(fvpng);
@@ -603,7 +603,7 @@ void foucaultView::draw_ROC_Scale(){
     double step = getStep();
     for (int i = 0; i< 17; ++i){
         double val =  (i - 8) * step * 5;  // label slider every 5 steps.
-        findChild<QLabel *>(QString().sprintf("l%d",i))->setText(QString::number(val));
+        findChild<QLabel *>(QString("l%1").arg(i))->setText(QString::number(val));
     }
 }
 

--- a/generatetargetdlg.cpp
+++ b/generatetargetdlg.cpp
@@ -108,7 +108,7 @@ void generateTargetDlg::on_generate_clicked()
         --hcnt;
         --vcnt;
     }
-    putText(chessBoard, QString().sprintf("%d X %d", hcnt, vcnt).toStdString().c_str(),
+    putText(chessBoard, QString("%1 X %2").arg(hcnt).arg(vcnt).toStdString().c_str(),
             Point(40,20),1,1,cv::Scalar(100, 100,100));
     //pyrDown(chessBoard,chessBoard);
     imshow("Grid pattern", chessBoard);

--- a/igramarea.cpp
+++ b/igramarea.cpp
@@ -314,8 +314,8 @@ Mat IgramArea::igramToGray(cv::Mat roi){
     static const char *colorNames[] = {"red","green","blue"};
     cv::Mat gray;
     cv::merge(planes, 3, gray);
-    emit imageSize(QString().sprintf("%d X %d using %s channel", igramColor.size().width(),
-                                     igramColor.size() .height(), colorNames[maxndx]));
+    emit imageSize(QString("%1 X %2 using %3 channel").arg(igramColor.size().width()).arg(
+                                     igramColor.size().height()).arg(colorNames[maxndx]));
     return gray;
 
 }
@@ -372,7 +372,7 @@ cv::Point2d IgramArea::findBestCenterOutline(cv::Mat gray, int start, int end,in
 
     for (int rad0 = start; rad0 != end;  rad0 += step){
         MainWindow::me->progBar->setValue(++cnt);
-        MainWindow::me->progBar->setFormat(QString().sprintf("Radius %d",rad0));
+        MainWindow::me->progBar->setFormat(QString("Radius %1").arg(rad0));
         // create a light gray image
         cv::Point insideCenter(cx, cy);
         cv::Mat circlem = cv::Mat::zeros(gray.size(), gray.type());
@@ -465,7 +465,7 @@ cv::Point2d IgramArea::findBestOutsideOutline(cv::Mat gray, int start, int end,i
     double downcnt = 0.;
     for (int rad0 = start; rad0 >= end;  rad0 += step){
         MainWindow::me->progBar->setValue(++cnt);
-        MainWindow::me->progBar->setFormat(QString().sprintf("Radius: %d",rad0));
+        MainWindow::me->progBar->setFormat(QString("Radius: %1").arg(rad0));
         qApp->processEvents();
 
         if (rad0 < 0)
@@ -486,7 +486,7 @@ cv::Point2d IgramArea::findBestOutsideOutline(cv::Mat gray, int start, int end,i
             cv::circle(t, c, rad0, cv::Scalar(255), 1);
             cv::imshow("outline debug",t);
             cv::waitKey(100);
-            emit statusBarUpdate(QString().sprintf(" rad %d Resp %6.3lf", rad0, resp),3);
+            emit statusBarUpdate(QString(" rad %1 Resp %2").arg(rad0).arg(resp, 6, 'f', 3),3);
         }
 
 
@@ -546,7 +546,7 @@ cv::Point2d IgramArea::findBestOutsideOutline(cv::Mat gray, int start, int end,i
     QwtPlot *plot = MainWindow::me->m_outlinePlots->getPLot(pass);
     plot->show();
     plot->detachItems( QwtPlotItem::Rtti_PlotCurve);
-    plot->setTitle(QString().sprintf("Outside pass %d",pass));
+    plot->setTitle(QString("Outside pass %1").arg(pass));
     plot->setAxisTitle(QwtPlot::xBottom, "Radius");
     plot->setAxisTitle(QwtPlot::yLeft, "strength");
     QwtPlotCurve  *curve = new QwtPlotCurve();
@@ -676,7 +676,7 @@ void IgramArea::findCenterHole(){
     double rmean;
     for (int rad = start; rad < end; ++rad){
         MainWindow::me->progBar->setValue(rad);
-        MainWindow::me->progBar->setFormat(QString().sprintf("Radius: %d",rad));
+        MainWindow::me->progBar->setFormat(QString("Radius: %1").arg(rad));
         qApp->processEvents();
         cv::Mat key = cv::Mat::ones(roi.rows, roi.cols, roi.type());
         key = cv::Scalar(250);
@@ -802,7 +802,7 @@ void IgramArea::findOutline(){
 
         radius /= scale;
         //searchMargin = 5./scale;
-        emit statusBarUpdate(QString().sprintf("margin %d %d", searchMargin, radius),3);
+        emit statusBarUpdate(QString("margin %1 %2").arg(searchMargin).arg(radius),3);
     }
     else {
       bestc = Point2d(m_outside.m_center.x(), m_outside.m_center.y());
@@ -943,7 +943,7 @@ void IgramArea::adjustCenterandRegions(){
         foreach(QString str, regionsList){
             if (str == "")
                 continue;
-            m_regionEdit->addRegion(QString().sprintf("Region %d",++r));
+            m_regionEdit->addRegion(QString("Region %1").arg(++r));
             QStringList vals = str.split(" ");
             std::vector< cv::Point> region;
             for (int i = 1; i < vals.size(); ++i){
@@ -1099,7 +1099,7 @@ void IgramArea::syncRegions(){
 
     m_regionEdit->clear();
     for (int n = 0; n < m_polygons.size(); ++n){
-        m_regionEdit->addRegion(QString().sprintf("Region %d", n+1));
+        m_regionEdit->addRegion(QString("Region %1").arg( n+1));
     }
 }
 
@@ -1359,7 +1359,7 @@ void IgramArea::deleteregion(int r){
 }
 
 void IgramArea::addregion(){
-    m_regionEdit->addRegion( QString().sprintf("Region %d",m_polygons.size()+1));
+    m_regionEdit->addRegion( QString("Region %1").arg(m_polygons.size()+1));
     m_polygons.append(std::vector< cv::Point>());
     polyndx = m_polygons.size()-1;
 }
@@ -1702,7 +1702,7 @@ void IgramArea::drawBoundary()
         if (inside.m_radius > 0 && innerPcount > 1){
             //painter.setPen(QPen(centerPenColor, centerPenWidth, (Qt::PenStyle)lineStyle));
             double percent = inside.m_radius/outside.m_radius * 100;
-            QString label = QString().sprintf("%6.2lf percent", percent);
+            QString label = QString("%1 percent").arg(percent, 6, 'f', 2);
             painter.setPen(Qt::black);
             QFont font("Arial", 8);
 
@@ -1750,14 +1750,14 @@ void IgramArea::drawBoundary()
                     painter.setPen(QPen(centerPenColor, centerPenWidth, (Qt::PenStyle)lineStyle));
                 }
                 QPointF p(m_polygons[n][0].x -10, m_polygons[n][0].y - 10);
-                painter.drawText(p,QString().sprintf("%d",n+1));
+                painter.drawText(p,QString("%1").arg(n+1));
                 if (m_polygons[n].size() > 1){
                     for (int j = 0; j < m_polygons[n].size()-1; ++j){
                         painter.drawLine(m_polygons[n][j].x, m_polygons[n][j].y,
                                          m_polygons[n][j+1].x, m_polygons[n][j+1].y);
                     }
                     QPointF p(m_polygons[n][0].x -10, m_polygons[n][0].y - 10);
-                    painter.drawText(p,QString().sprintf("%d",n+1));
+                    painter.drawText(p,QString("%1").arg(n+1));
                 }
                 if (regionMode){
 
@@ -1790,10 +1790,13 @@ void IgramArea::drawBoundary()
     if (outterPcount == 2){
         QString vert = "";
         if (mirrorDlg::get_Instance()->isEllipse()){
-            vert = QString().sprintf("Vertical Axis: %6.1f", outside.m_radius * s2);
+            vert = QString("Vertical Axis: %1").arg(outside.m_radius * s2, 6, 'f', 1);
         }
-        msg = QString().sprintf("Outside: x=%6.1lf y=%6.1lf, Radius= %6.1lf  %s",
-                                outside.m_center.x(),outside.m_center.y(), outside.m_radius,vert.toStdString().c_str());
+        msg = QString("Outside: x=%1 y=%2, Radius= %3  %4").arg(
+                                outside.m_center.x(), 6 , 'f', 1).arg(
+                                    outside.m_center.y(), 6, 'f', 1).arg(
+                                        outside.m_radius, 6, 'f', 1).arg(
+                                            vert.toStdString().c_str());
 
     }
     m_outside = outside;
@@ -1801,8 +1804,11 @@ void IgramArea::drawBoundary()
         m_center = inside;
 
 
-        msg2 = QString().sprintf("center= %6.1lf,%6.1lf radius = %6.2lf scale =%6.2lf",
-                                 inside.m_center.x(),inside.m_center.y(),inside.m_radius, scale);
+        msg2 = QString("center= %1,%2 radius = %3 scale =%4").arg(
+                                 inside.m_center.x(), 6, 'f', 1).arg(
+                                    inside.m_center.y(), 6, 'f', 1).arg(
+                                        inside.m_radius, 6, 'f', 2).arg(
+                                            scale, 6, 'f', 2);
     }
     if (m_current_boundry != PolyArea)
         emit statusBarUpdate(msg+msg2,1);
@@ -2061,7 +2067,9 @@ void IgramArea::crop() {
     hasBeenCropped = true;
     scale = fitScale = (double)parentWidget()->height()/(double)igramGray.height();
     update();
-    emit imageSize(QString().sprintf("%d X %d", igramGray.size().width(), igramGray.size() .height()));
+    emit imageSize(QString("%1 X %2").arg(
+        igramGray.size().width()).arg(
+            igramGray.size() .height()));
     emit upateColorChannels(qImageToMat(igramColor));
 
 }
@@ -2145,7 +2153,7 @@ void IgramArea::loadOutlineFile(QString fileName){
         if (line == "Poly"){
             std::getline(file,line);
             m_polygons.push_back(std::vector< cv::Point>());
-            m_regionEdit->addRegion(QString().sprintf("Region %d", m_polygons.size()));
+            m_regionEdit->addRegion(QString("Region %1").arg( m_polygons.size()));
             QStringList data = QString::fromStdString(line).split(" ");
             for (int i = 0; i < data.size()-1; ++i){
                 QStringList vals = data[i].split(",");
@@ -2165,8 +2173,8 @@ void IgramArea::loadOutlineFile(QString fileName){
 );
 
                 QMessageBox mb;
-                mb.setText(QString().sprintf("Edge mask value in outline file for this interferogram is %6.1lf and is different than mirror config value of %6.1lf.",
-                                             edge, md.aperatureReduction) );
+                mb.setText(QString("Edge mask value in outline file for this interferogram is %1 and is different than mirror config value of %2.").arg(
+                                             edge, 6, 'f', 1).arg(md.aperatureReduction, 6, 'f', 1) );
                 mb.setInformativeText(text);
                 mb.setStandardButtons( QMessageBox::Yes|QMessageBox::No );
                 mb.setWindowTitle("Existing Interferogram outline file and Mirror Config difference.");
@@ -2200,11 +2208,16 @@ void IgramArea::loadOutlineFile(QString fileName){
     m_outsideHist.push(igramGray,m_outside);
     emit enableShiftButtons(true);
 
-    QString msg2 = QString().sprintf("center= %6.1lf,%6.1lf radius = %6.2lf scale =%6.2lf",
-                             m_outside.m_center.x(),m_outside.m_center.y(),m_outside.m_radius, scale);
+    QString msg2 = QString("center= %1,%2 radius = %3 scale =%4").arg(
+                             m_outside.m_center.x(), 6, 'f', 1).arg(
+                                m_outside.m_center.y(), 6, 'f', 1).arg(
+                                    m_outside.m_radius, 6, 'f', 2).arg(
+                                        scale, 6, 'f', 2);
     if (m_center.m_radius > 0){
-        msg2 += QString().sprintf(" center outline: center= %6.1lf,%6.1lf radius = %6.2lf",
-                                  m_center.m_center.x(), m_center.m_center.y(), m_center.m_radius);
+        msg2 += QString(" center outline: center= %1,%2 radius = %3").arg(
+                                  m_center.m_center.x(), 6, 'f', 1).arg(
+                                    m_center.m_center.y(), 6, 'f', 1).arg(
+                                        m_center.m_radius, 6, 'f', 2);
     }
     emit statusBarUpdate(msg2,1);
 }

--- a/intensityplot.cpp
+++ b/intensityplot.cpp
@@ -64,7 +64,7 @@ public:
         dx = m_rad  - xx * cos(i_angle);
         dy = m_rad  - xx * sin(i_angle);
         if (dy >= m_plane.rows || dx >= m_plane.cols || dy < 0 || dx < 0){
-            //qDebug() << QString().sprintf("profile Warning index out of range %d %d", dx,dy);
+            //qDebug() << QString("profile Warning index out of range %1 %1").arg(dx).arg(dy);
             return 0.0;
         }
         double v = m_plane.at<uchar>(dy,dx);

--- a/intensityplot.cpp
+++ b/intensityplot.cpp
@@ -64,7 +64,7 @@ public:
         dx = m_rad  - xx * cos(i_angle);
         dy = m_rad  - xx * sin(i_angle);
         if (dy >= m_plane.rows || dx >= m_plane.cols || dy < 0 || dx < 0){
-            //qDebug() << QString("profile Warning index out of range %1 %1").arg(dx).arg(dy);
+            //qDebug() << QString("profile Warning index out of range %1 %2").arg(dx).arg(dy);
             return 0.0;
         }
         double v = m_plane.at<uchar>(dy,dx);

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -1626,7 +1626,7 @@ void MainWindow::on_actionCreate_Movie_of_wavefronts_triggered()
 //                fileName.append(".avi");
 //            cv::VideoWriter video(fileName.toStdString().c_str(),-1,4,cv::Size(width,height),true);
 //            if (!video.isOpened()){
-//                QString msg = QString("could not open %1 %2x%3 for writing.").arg(fileName.toStdString().c_str()).arg(
+//                QString msg = QString("could not open %1 %2x%3 for writing.").arg(fileName).arg(
 //                                                width).arg(height);
 //                QMessageBox::warning(0,"warning", msg);
 //                return;

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -491,7 +491,7 @@ void MainWindow::createDockWindows(){
     m_contourTools->setAllowedAreas(Qt::LeftDockWidgetArea | Qt::RightDockWidgetArea);
     m_dftTools->setAllowedAreas(Qt::LeftDockWidgetArea | Qt::RightDockWidgetArea);
     metrics = metricsDisplay::get_instance(this);
-    metrics->setWindowTitle(QString().sprintf("metrics      DFTFringe %s",APP_VERSION));
+    metrics->setWindowTitle(QString("metrics      DFTFringe %s").arg(APP_VERSION));
     zernTablemodel = metrics->tableModel;
     addDockWidget(Qt::LeftDockWidgetArea, m_outlineHelp);
     addDockWidget(Qt::LeftDockWidgetArea, m_outlinePlots);
@@ -517,14 +517,14 @@ void MainWindow::createDockWindows(){
 }
 void MainWindow::updateMetrics(wavefront& wf){
     metrics->setName(wf.name);
-    metrics->mDiam->setText(QString().sprintf("%6.3lf",wf.diameter));
-    metrics->mROC->setText(QString().sprintf("%6.3lf",wf.roc));
+    metrics->mDiam->setText(QString("%1").arg(wf.diameter, 6, 'f', 3));
+    metrics->mROC->setText(QString("%1").arg(wf.roc, 6, 'f', 3));
     const double  e = 2.7182818285;
-    metrics->mRMS->setText(QString().sprintf("<b><FONT FONT SIZE = 12>%6.3lf</b>",wf.std));
+    metrics->mRMS->setText(QString("<b><FONT FONT SIZE = 12>%1</b>").arg(wf.std, 6, 'f', 3));
     double st =(2. *M_PI * wf.std);
     st *= st;
     double Strehl = pow(e, -st);
-    metrics->mStrehl->setText(QString().sprintf("<b><FONT FONT SIZE = 12>%6.3lf</b>",Strehl));
+    metrics->mStrehl->setText(QString("<b><FONT FONT SIZE = 12>%1</b>").arg(Strehl, 6, 'f', 3));
 
 
     double z8 = zernTablemodel->values[8];
@@ -538,7 +538,7 @@ void MainWindow::updateMetrics(wavefront& wf){
 
     metrics->setWavePerFringe(m_mirrorDlg->fringeSpacing, m_mirrorDlg->lambda);
     if (m_mirrorDlg->doNull)
-        metrics->mCC->setText(QString().sprintf("<FONT FONT SIZE = 7>%6.3lf",BestSC));
+        metrics->mCC->setText(QString("<FONT FONT SIZE = 7>%1").arg(BestSC, 6 ,'f', 3));
     else {
         metrics->mCC->setText("NA");
     }
@@ -941,7 +941,7 @@ void MainWindow::on_actionAbout_triggered()
 {
 
     QMessageBox::information(this, "___________________________________________________________________________About", 
-                            QString().sprintf("<html><body><h1>DFTFringe version %s</h1>",APP_VERSION)+
+                            QString("<html><body><h1>DFTFringe version %1</h1>").arg(APP_VERSION)+
                              "<p>This program was compiled using:<ul><li>"
                              "Qt version " + QT_VERSION_STR + " </li>"
                     #if defined(__GNUC__) && defined(__VERSION__)
@@ -1214,10 +1214,11 @@ void MainWindow::batchProcess(QStringList fileList){
                 double cx = set.value("lastOutsideCx",0).toDouble();
                 double cy = set.value("lastOutsideCy",0.).toDouble();
                 wavefront *wf = m_surfaceManager->m_wavefronts[m_surfaceManager->m_currentNdx];
-                QString txt = QString().sprintf("%s RMS: %6.3lf outline center x,y: %6.1lf, %6.1lf",
-                                                info.baseName().toStdString().c_str(),
-                                                wf->std,
-                                                cx,cy);
+                QString txt = QString("%1 RMS: %2 outline center x,y: %3, %4").arg(
+                                                info.baseName().toStdString().c_str()).arg(
+                                                wf->std, 6, 'f', 3).arg(
+                                                cx, 6, 'f', 1).arg(
+                                                cy, 6, 'f', 1);
                 painter.drawText(20,height/2 + 15, txt);
                 cv::Mat frame = cv::Mat(img.height(), img.width(),CV_8UC4, img.bits(), img.bytesPerLine()).clone();
                 cv::Mat resized;
@@ -1356,7 +1357,7 @@ void MainWindow::startJitter(){
         m_dftArea->makeSurface();
         qApp->processEvents();
         wavefront *wf = m_surfaceManager->m_wavefronts[m_surfaceManager->m_currentNdx];
-        wf->name = QString().sprintf("x:_%d_Y:_%d_radius:_%d",x,y,rad);
+        wf->name = QString("x:_%1_Y:_%2_radius:_%3").arg(x).arg(y).arg(rad);
         dlg->status(wf->name);
         m_surfTools->nameChanged(m_surfaceManager->m_currentNdx, wf->name);
         qApp->processEvents();
@@ -1625,14 +1626,14 @@ void MainWindow::on_actionCreate_Movie_of_wavefronts_triggered()
 //                fileName.append(".avi");
 //            cv::VideoWriter video(fileName.toStdString().c_str(),-1,4,cv::Size(width,height),true);
 //            if (!video.isOpened()){
-//                QString msg = QString().sprintf("could not open %s %dx%d for writing.", fileName.toStdString().c_str(),
-//                                                width, height);
+//                QString msg = QString("could not open %1 %2x%3 for writing.").arg(fileName.toStdString().c_str()).arg(
+//                                                width).arg(height);
 //                QMessageBox::warning(0,"warning", msg);
 //                return;
 //            }
 //            foreach (QString name, fileNames){
 //                int mem = showmem("loading");
-//                statusBar()->showMessage(QString().sprintf("memory %d MB", mem));
+//                statusBar()->showMessage(QString("memory %1 MB").arg(mem));
 //                if (mem< memThreshold + 50){
 //                    while (m_surfaceManager->m_wavefronts.size() > 1){
 //                        m_surfaceManager->deleteCurrent();

--- a/metricsdisplay.cpp
+++ b/metricsdisplay.cpp
@@ -55,11 +55,11 @@ metricsDisplay *metricsDisplay::get_instance(QWidget *parent){
     return m_instance;
 }
 void metricsDisplay::setWavePerFringe(double val, double lambda){
-    ui->wavesPerFringe->setText(QString().sprintf("Waves Per Fringe: %2.1lf",val));
-    ui->lambda->setText(QString().sprintf("Igram laser wavelength: %6.2lf nm",lambda));
+    ui->wavesPerFringe->setText(QString("Waves Per Fringe: %1").arg(val, 2, 'f', 1));
+    ui->lambda->setText(QString("Igram laser wavelength: %1 nm").arg(lambda, 6, 'f', 2));
     mirrorDlg *md = mirrorDlg::get_Instance();
-    QString donull = (md->doNull) ? (QString().sprintf("SANull: %6.4lf",md->z8 * md->cc)) : "";
-    ui->desiredConicLb->setText(QString().sprintf("Desired Conic: %6.2lf ", md->cc) + donull);
+    QString donull = (md->doNull) ? (QString("SANull: %1").arg(md->z8 * md->cc, 6, 'f', 4)) : "";
+    ui->desiredConicLb->setText(QString("Desired Conic: %1 ").arg( md->cc, 6, 'f', 2) + donull);
     ui->zernTitle->setText( "Zernike Values @ interferogram wavelength");
     if (md->isEllipse()){
         ui->desiredConicLb->setText("");
@@ -67,7 +67,7 @@ void metricsDisplay::setWavePerFringe(double val, double lambda){
     }
 }
 void metricsDisplay::setOutputLambda(double val){
-    ui->label_5->setText(QString().sprintf("Wavefront RMS at %6.1lf nm", val));
+    ui->label_5->setText(QString("Wavefront RMS at %1 nm").arg(val, 6, 'f', 1));
 }
 
 void metricsDisplay::setName(QString name){

--- a/mirrordlg.cpp
+++ b/mirrordlg.cpp
@@ -142,7 +142,7 @@ void mirrorDlg::on_saveBtn_clicked()
     if (fileName.isEmpty())
         return;
     if (QFileInfo(fileName).suffix().isEmpty()) { fileName.append(".ini"); }
-    std::ofstream file((fileName.toStdString().c_str()),std::ios_base::out|std::ios_base::binary);
+    std::ofstream file(fileName.toStdString().c_str(),std::ios_base::out|std::ios_base::binary);
     if (!file.is_open()) {
         QMessageBox::warning(0, tr("Save mirror config."),
                              tr("Cannot write file %1: ")

--- a/mirrordlg.cpp
+++ b/mirrordlg.cpp
@@ -66,18 +66,18 @@ mirrorDlg::mirrorDlg(QWidget *parent) :
         ui->rocLab->show();
         ui->fnumberLab->show();
         ui->FNumber->show();
-        ui->roc->setText(QString().sprintf("%6.2lf",roc));
-        ui->FNumber->setText(QString().sprintf("%6.2lf",FNumber));
+        ui->roc->setText(QString("%1").arg(roc, 6, 'f', 2));
+        ui->FNumber->setText(QString("%1").arg(FNumber, 6, 'f', 2));
     }
     lambda = settings.value("config lambda", 640).toDouble();
 
-    ui->lambda->setText(QString().sprintf("%6.1lf",lambda));
+    ui->lambda->setText(QString("%1").arg(lambda, 6 ,'f' ,1));
 
     obs = settings.value("config obstruction", 0.).toDouble();
 
     cc = settings.value("config cc", -1.).toDouble();
 
-    ui->cc->setText(QString().sprintf("%6.2lf",cc));
+    ui->cc->setText(QString("%1").arg(cc, 6, 'f', 2));
 
     ui->ReducApp->setChecked( m_aperatureReductionEnabled);
     if (  m_aperatureReductionEnabled)
@@ -93,7 +93,7 @@ mirrorDlg::mirrorDlg(QWidget *parent) :
     m_projectPath = settings.value("projectPath", "").toString();
     fringeSpacing = settings.value("config fringe spacing", 1.).toDouble();
 
-    ui->fringeSpacingEdit->setText(QString().sprintf("%3.2lf",fringeSpacing));
+    ui->fringeSpacingEdit->setText(QString("%1").arg(fringeSpacing, 6, 'f', 3));
     ui->fringeSpacingEdit->blockSignals(false);
     m_outlineShape = (outlineShape)settings.value("outlineShape", CIRCLE).toInt();
     ui->minorAxisEdit->setText(QString::number(settings.value("ellipseMinorAxis", 50.).toDouble()));
@@ -102,8 +102,8 @@ mirrorDlg::mirrorDlg(QWidget *parent) :
         m_verticalAxis = diameter;
     ui->ellipseShape->setChecked(m_outlineShape == ELLIPSE);
     ui->minorAxisEdit->setText(QString().number(m_verticalAxis));
-    ui->diameter->setText(QString().sprintf("%6.2lf",diameter));
-    ui->obs->setText(QString().sprintf("%6.2lf",obs));
+    ui->diameter->setText(QString("%1").arg(diameter, 6, 'f', 2));
+    ui->obs->setText(QString("%1").arg(obs, 6, 'f', 2));
     ui->FNumber->blockSignals(false);
     ui->roc->blockSignals(false);
     ui->lambda->blockSignals(false);
@@ -250,7 +250,7 @@ void mirrorDlg::loadFile(QString & fileName){
         double *dp = (double*)buf;
         fringeSpacing = *dp;
         ui->fringeSpacingEdit->blockSignals(true);
-        ui->fringeSpacingEdit->setText(QString().sprintf("%3.1lf",*dp));
+        ui->fringeSpacingEdit->setText(QString("%1").arg(*dp, 3, 'f', 1));
         ui->fringeSpacingEdit->blockSignals(false);
 
         //read diameter
@@ -281,10 +281,10 @@ void mirrorDlg::loadFile(QString & fileName){
             //roc *= 25.4;
         }
         ui->diameter->blockSignals(true);
-        ui->diameter->setText(QString().sprintf("%6.2lf",diameter));
+        ui->diameter->setText(QString("%1").arg(diameter, 6, 'f', 2));
         ui->diameter->blockSignals(false);
         ui->roc->blockSignals(true);
-        ui->roc->setText(QString().sprintf("%6.2lf",roc));
+        ui->roc->setText(QString("%1").arg(roc, 6, 'f', 2));
         ui->roc->blockSignals(false);
 
         //conic
@@ -329,7 +329,7 @@ void mirrorDlg::loadFile(QString & fileName){
 
         FNumber = roc/(2. * diameter);
         ui->FNumber->blockSignals(true);
-        ui->FNumber->setText(QString().sprintf("%6.2lf",FNumber));
+        ui->FNumber->setText(QString("%1").arg(FNumber, 6, 'f', 2));
         ui->FNumber->blockSignals(false);
 
         file.close();
@@ -363,7 +363,7 @@ void mirrorDlg::on_diameter_textChanged(const QString &arg1) {
     diameter = diam;
     FNumber = roc/(2. * diameter);
     ui->FNumber->blockSignals(true);
-    ui->FNumber->setText(QString().sprintf("%6.2lf",FNumber));
+    ui->FNumber->setText(QString("%1").arg(FNumber, 6, 'f', 2));
     ui->FNumber->blockSignals(false);
     updateZ8();
 
@@ -381,8 +381,8 @@ void mirrorDlg::on_diameter_Changed(const double diam)
     FNumber = roc/(2. * diameter);
     ui->FNumber->blockSignals(true);
     const QSignalBlocker blocker(ui->diameter);
-    ui->FNumber->setText(QString().sprintf("%6.2lf",FNumber *( (mm) ? 1.: 25.4)));
-    ui->diameter->setText(QString().sprintf("%6.2lf",diameter * ((mm) ? 1.: 25.4)));
+    ui->FNumber->setText(QString("%1").arg(FNumber *( (mm) ? 1.: 25.4), 6, 'f', 2));
+    ui->diameter->setText(QString("%1").arg(diameter * ((mm) ? 1.: 25.4), 6, 'f', 2));
     ui->FNumber->blockSignals(false);
     ui->diameter->blockSignals(false);
 
@@ -396,7 +396,7 @@ void mirrorDlg::on_roc_textChanged(const QString &arg1)
     roc = arg1.toDouble() * ((mm) ? 1: 25.4);
     FNumber = roc /(2. * diameter);
     ui->FNumber->blockSignals(true);
-    ui->FNumber->setText(QString().sprintf("%6.2lf",FNumber));
+    ui->FNumber->setText(QString("%1").arg(FNumber, 6, 'f', 2));
     ui->FNumber->blockSignals(false);
     updateZ8();
 }
@@ -408,10 +408,10 @@ void mirrorDlg::on_roc_Changed(const double newVal)
 
     FNumber = roc /(2. * diameter);
     ui->FNumber->blockSignals(true);
-    ui->FNumber->setText(QString().sprintf("%6.2lf",FNumber * ((mm) ? 1.: 25.4)));
+    ui->FNumber->setText(QString("%1").arg(FNumber * ((mm) ? 1.: 25.4), 6, 'f', 2));
     ui->FNumber->blockSignals(false);
     ui->roc->blockSignals(true);
-    ui->roc->setText(QString().sprintf("%6.2lf",roc * ((mm) ? 1.: 25.4)));
+    ui->roc->setText(QString("%1").arg(roc * ((mm) ? 1.: 25.4), 6, 'f', 2));
     ui->roc->blockSignals(false);
     updateZ8();
 }
@@ -485,20 +485,20 @@ void mirrorDlg::on_unitsCB_clicked(bool checked)
 
     ui->roc->blockSignals(true);
     ui->diameter->blockSignals(true);
-     ui->diameter->setText(QString().sprintf("%6.2lf",diameter/div));
+     ui->diameter->setText(QString("%1").arg(diameter/div, 6, 'f', 2));
      ui->roc->setText(QString().number(roc/div));
      ui->obs->setText(QString().number(obs/div));
      ui->diameter->blockSignals(false);
      ui->roc->blockSignals(false);
      ui->minorAxisEdit->blockSignals(true);
-     ui->minorAxisEdit->setText(QString().sprintf(("%6.2lf"),m_verticalAxis/div));
+     ui->minorAxisEdit->setText(QString("%1").arg(m_verticalAxis/div, 6, 'f', 2));
      ui->reduceValue->blockSignals(true);
      QSettings set;
      aperatureReduction = set.value("config aperatureReduction",0.).toDouble();
 
      ui->reduceValue->setValue(aperatureReduction * ((mm) ? 1. : 1./25.4));
      ui->reduceValue->blockSignals(false);
-     ui->ClearAp->setText(QString().sprintf("%6.2lf ", m_clearAperature * ((mm) ? 1: 1./25.4)));
+     ui->ClearAp->setText(QString("%1 ").arg(m_clearAperature * ((mm) ? 1: 1./25.4), 6, 'f', 2));
 }
 
 void mirrorDlg::on_buttonBox_accepted()
@@ -599,7 +599,7 @@ void mirrorDlg::on_buttonBox_helpRequested()
 void mirrorDlg::setclearAp(){
 
     m_clearAperature = (diameter - aperatureReduction * 2) ;
-    ui->ClearAp->setText(QString().sprintf("%6.2lf ", m_clearAperature * ((mm) ? 1: 1./25.4)));
+    ui->ClearAp->setText(QString("%1 ").arg(m_clearAperature * ((mm) ? 1: 1./25.4), 6, 'f', 2));
 }
 
 void mirrorDlg::on_ReducApp_clicked(bool checked)

--- a/nullvariationdlg.cpp
+++ b/nullvariationdlg.cpp
@@ -160,8 +160,8 @@ void nullVariationDlg::calculate()
 
     //qDebug() << "z8 compared to z " << center << ((1.5) * pow(diam+d_tol,4) * 1.E6 /(384. * lambda * pow(roc,3)) - center) << diamPV;
 
-    ui->diamPV->setText(QString("%1    %2%%").arg(diamPV, 6, 'f', 4).arg(100. * diamPV/center, 6, 'f', 2));
-    ui->rocPV->setText(QString( "%1    %2%%").arg(rocPV, 6, 'f', 4).arg(100. * rocPV /center, 6, 'f', 2));
+    ui->diamPV->setText(QString("%1    %2%").arg(diamPV, 6, 'f', 4).arg(100. * diamPV/center, 6, 'f', 2));
+    ui->rocPV->setText(QString( "%1    %2%").arg(rocPV, 6, 'f', 4).arg(100. * rocPV /center, 6, 'f', 2));
 
     double big1 = ((1.5) * pow(diam+d_tol,4) * 1.E6 /(384. * lambda * pow(roc-roc_tol,3)));
     double big2 = ((1.5) * pow(diam-d_tol,4) * 1.E6 /(384. * lambda * pow(roc+roc_tol,3)));

--- a/nullvariationdlg.cpp
+++ b/nullvariationdlg.cpp
@@ -160,12 +160,12 @@ void nullVariationDlg::calculate()
 
     //qDebug() << "z8 compared to z " << center << ((1.5) * pow(diam+d_tol,4) * 1.E6 /(384. * lambda * pow(roc,3)) - center) << diamPV;
 
-    ui->diamPV->setText(QString().sprintf("%6.4lf    %6.2lf%%", diamPV, 100. * diamPV/center));
-    ui->rocPV->setText(QString().sprintf( "%6.4lf    %6.2lf%%",rocPV, 100. * rocPV /center));
+    ui->diamPV->setText(QString("%1    %2%%").arg(diamPV, 6, 'f', 4).arg(100. * diamPV/center, 6, 'f', 2));
+    ui->rocPV->setText(QString( "%1    %2%%").arg(rocPV, 6, 'f', 4).arg(100. * rocPV /center, 6, 'f', 2));
 
     double big1 = ((1.5) * pow(diam+d_tol,4) * 1.E6 /(384. * lambda * pow(roc-roc_tol,3)));
     double big2 = ((1.5) * pow(diam-d_tol,4) * 1.E6 /(384. * lambda * pow(roc+roc_tol,3)));
-    ui->result->setText(QString().sprintf("%6.4lf  %6.4lf", sqrt(pow(diamPV,2) + pow(rocPV,2)), (big1 - big2)/2));
+    ui->result->setText(QString("%1  %2").arg(sqrt(pow(diamPV,2) + pow(rocPV,2)), 6, 'f', 4).arg((big1 - big2)/2, 6, 'f', 4));
     m_guiTimer.start(3000);
 }
 
@@ -248,7 +248,7 @@ void nullVariationDlg::on_ComputeSim_clicked()
 
         }
 
-        QwtPlotCurve *histPlot = new QwtPlotCurve(QString().sprintf("diameter tolerance:%6.1f      ROC tolerance:%6.1lf",d_tol,roc_tol));
+        QwtPlotCurve *histPlot = new QwtPlotCurve(QString("diameter tolerance:%1      ROC tolerance:%2").arg(d_tol, 6, 'f', 1).arg(roc_tol, 6, 'f', 1));
         QwtPlotMarker *mY = new QwtPlotMarker();
         mY->setLabel( QString::fromLatin1( "68%" ) );
         mY->setLabelAlignment( Qt::AlignRight | Qt::AlignBottom );

--- a/oglview.cpp
+++ b/oglview.cpp
@@ -198,7 +198,7 @@ void OGLView::showSelected()    // show all selected wavefronts as 3D plots
         p2.setFont(serifFont);
         p2.setPen(QPen(QColor(Qt::white)));
         QStringList l = wf->name.split("/");
-        p2.drawText(10,40,l[l.size()-1] + QString().sprintf("%6.3lf RMS",wf->std));
+        p2.drawText(10,40,l[l.size()-1] + QString("%1 RMS").arg(wf->std, 6, 'f', 3));
         int y_offset =  height * (i/columns) + 40;
         int x_offset = width * (i%columns) + 20;
         painter.drawImage(x_offset,y_offset, glImage.scaled(width, height,Qt::KeepAspectRatio));

--- a/outlinedialog.cpp
+++ b/outlinedialog.cpp
@@ -225,7 +225,7 @@ void outlineDialog::updateOutline(){
 //    maxBox.points(vtx);
 //    for( int j = 0; j < 4; j++ )
 //        line(display, vtx[j], vtx[(j+1)%4], cv::Scalar(0,255,0), 1, CV_AA);
-    ui->status->setText( QString().sprintf("x,y %6.1lf,%6.1lf radius:%6.1lf ",x,y,radius));
+    ui->status->setText( QString("x,y %1,%2 radius:%3 ").arg(x, 6, 'f', 1).arg(y, 6, 'f', 1).arg(radius, 6, 'f', 1));
 
     updateDisplay(display);
 }

--- a/outlinestatsdlg.cpp
+++ b/outlinestatsdlg.cpp
@@ -29,9 +29,9 @@ protected:
     int ndx = p.x();
     //qDebug() << "tracker"<< cx << cy << p;
     if (ndx > 0 && ndx < m_outlines.m_names.size()){
-        QString msg = QString().sprintf("%s \n%6.1lf,%6.1lf",
-                                        m_outlines.m_names[ndx].split("/").back().toStdString().c_str(),
-                                        m_outlines.xvals[ndx], m_outlines.yvals[ndx]);
+        QString msg = QString("%1 \n%2,%3").arg(
+                                        m_outlines.m_names[ndx].split("/").back().toStdString().c_str()).arg(
+                                        m_outlines.xvals[ndx], 6, 'f', 1).arg(m_outlines.yvals[ndx], 6, 'f', 1);
         QwtText text(msg);
         text.setColor( Qt::black );
         text.setFont(QFont("Arial",12));
@@ -158,7 +158,7 @@ void outlineStatsDlg::plot(){
     ui->mirrorRadiusHistogramPlot->setAxisTitle(QwtPlot::yLeft, "sample count");
     ui->mirrorCenterPlot->setAxisTitle(QwtPlot::yLeft, "Position");
     ui->mirrorRadiusPlot->setAxisTitle(QwtPlot::yLeft, "radius");
-    ui->mirrorCenterPlot->setAxisTitle(QwtPlot::xBottom, QString().sprintf(" %d samples", m_names.size()));
+    ui->mirrorCenterPlot->setAxisTitle(QwtPlot::xBottom, QString(" %1 samples").arg(m_names.size()));
     xpos->setSamples(sn,xvals);
     xpos->setStyle(QwtPlotCurve::Dots);
     xpos->setPen(Qt::red,4);

--- a/outlinestatsdlg.cpp
+++ b/outlinestatsdlg.cpp
@@ -30,7 +30,7 @@ protected:
     //qDebug() << "tracker"<< cx << cy << p;
     if (ndx > 0 && ndx < m_outlines.m_names.size()){
         QString msg = QString("%1 \n%2,%3").arg(
-                                        m_outlines.m_names[ndx].split("/").back().toStdString().c_str()).arg(
+                                        m_outlines.m_names[ndx].split("/").back()).arg(
                                         m_outlines.xvals[ndx], 6, 'f', 1).arg(m_outlines.yvals[ndx], 6, 'f', 1);
         QwtText text(msg);
         text.setColor( Qt::black );

--- a/pixelstats.cpp
+++ b/pixelstats.cpp
@@ -197,7 +197,7 @@ void CanvasPicker::move( const QPoint &pos )
         d_selectedMarker->setLabel( QString("%1").arg(x, 0, 'f') ) ;
     }
     g_centerMarker->setXValue( (g_ub + g_lb)/2.);
-    g_centerMarker->setLabel(QString("PV %0").arg(g_ub -g_lb, 0, 'f'));
+    g_centerMarker->setLabel(QString("PV %1").arg(g_ub -g_lb, 0, 'f'));
 
     /*
        Enable QwtPlotCanvas::ImmediatePaint, so that the canvas has been

--- a/pixelstats.cpp
+++ b/pixelstats.cpp
@@ -189,15 +189,15 @@ void CanvasPicker::move( const QPoint &pos )
     d_selectedMarker->setXValue(x);
     if (idx ==0){
         g_lb = d_selectedMarker->xValue();
-        d_selectedMarker->setLabel( QString().sprintf("%lf", x) ) ;
+        d_selectedMarker->setLabel( QString("%1").arg(x, 0, 'f') ) ;
 
     }
     else {
         g_ub = d_selectedMarker->xValue();
-        d_selectedMarker->setLabel( QString().sprintf("%lf", x) ) ;
+        d_selectedMarker->setLabel( QString("%1").arg(x, 0, 'f') ) ;
     }
     g_centerMarker->setXValue( (g_ub + g_lb)/2.);
-    g_centerMarker->setLabel(QString().sprintf("PV %lf", (g_ub -g_lb)));
+    g_centerMarker->setLabel(QString("PV %0").arg(g_ub -g_lb, 0, 'f'));
 
     /*
        Enable QwtPlotCanvas::ImmediatePaint, so that the canvas has been
@@ -243,6 +243,7 @@ void CanvasPicker::shiftCurveCursor()
         if ( it == curveList.end() ) // not found
             it = curveList.begin();
 
+        const bool up = true;
         if ( up )
         {
             ++it;
@@ -540,7 +541,7 @@ void  pixelStats::updateHisto(){
     muY->setLinePen( Qt::red, 1 );
 
     double ub = g_ub;
-    muY->setLabel( QString().sprintf("%lf", ub) ) ;
+    muY->setLabel( QString("%1").arg(ub, 0 , 'f') ) ;
     muY->setXValue(ub );
     muY->attach( ui->histo);
     histPlot->setSamples(histData);
@@ -554,12 +555,12 @@ void  pixelStats::updateHisto(){
     mlY->setLinePen( Qt::blue, 1 );
 
     double lb = g_lb;
-    mlY->setLabel( QString().sprintf("%lf", lb) ) ;
+    mlY->setLabel( QString("%1").arg(lb, 0 , 'f') ) ;
     mlY->setXValue(lb );
     mlY->attach( ui->histo);
 
     QwtPlotMarker *lab = g_centerMarker = new QwtPlotMarker();
-    lab->setLabel(QString().sprintf("PV %lf", (ub -lb)));
+    lab->setLabel(QString("PV %1").arg(ub -lb, 0, 'f'));
     lab->setLineStyle( QwtPlotMarker::VLine );
     lab->setLinePen(Qt::black,0, Qt::DotLine);
     lab->setXValue((ub+lb)/2.);

--- a/profileplot.cpp
+++ b/profileplot.cpp
@@ -411,7 +411,7 @@ void ProfilePlot::populate()
     compass->setGeometry(QRect(80,80,70,70));
     QString tmp("nanometers");
     if (m_showNm == 1.)
-        tmp = QString().sprintf("waves of %6.1lf nm",outputLambda);
+        tmp = QString("waves of %1 nm").arg(outputLambda, 6, 'f', 1);
     m_plot->setAxisTitle( m_plot->yLeft, "Error in " + tmp );
     m_plot->setAxisTitle( m_plot->xBottom, "Radius mm" );
 
@@ -429,7 +429,7 @@ void ProfilePlot::populate()
 
     if (m_wf->m_outside.m_radius > 0 && settings.value("GBlur", false).toBool()){
         double val = .01 * (m_wf->diameter) * smoothing;
-        QString t = QString().sprintf("Surface Smoothing diameter %6.2lf%% of surface diameter %6.1lf mm", smoothing , val );
+        QString t = QString("Surface Smoothing diameter %1%% of surface diameter %2 mm").arg(smoothing, 6, 'f', 2).arg( val, 6, 'f', 1 );
         QwtText title(t);
         title.setRenderFlags( Qt::AlignHCenter | Qt::AlignTop );
 

--- a/profileplot.cpp
+++ b/profileplot.cpp
@@ -429,7 +429,7 @@ void ProfilePlot::populate()
 
     if (m_wf->m_outside.m_radius > 0 && settings.value("GBlur", false).toBool()){
         double val = .01 * (m_wf->diameter) * smoothing;
-        QString t = QString("Surface Smoothing diameter %1%% of surface diameter %2 mm").arg(smoothing, 6, 'f', 2).arg( val, 6, 'f', 1 );
+        QString t = QString("Surface Smoothing diameter %1% of surface diameter %2 mm").arg(smoothing, 6, 'f', 2).arg( val, 6, 'f', 1 );
         QwtText title(t);
         title.setRenderFlags( Qt::AlignHCenter | Qt::AlignTop );
 

--- a/psi_dlg.cpp
+++ b/psi_dlg.cpp
@@ -90,7 +90,7 @@ void PSI_dlg::on_browse_clicked()
 
                 double ang2 = startAngle + index++ * deltaAngle;
                 while (ang2 > 360.) ang2 -= 360.;
-                ui->PhaseList->addItem(QString().sprintf("%6.2lf",ang2));
+                ui->PhaseList->addItem(QString("%1").arg(ang2, 6, 'f', 2));
                 QListWidgetItem* item = ui->PhaseList->item(ui->PhaseList->count()-1);
                 item->setFlags(item->flags() | Qt::ItemIsEditable);
                 m_phases << ang2 * M_PI/180.;
@@ -194,7 +194,7 @@ void PSI_dlg::on_PSIPhaseValue_valueChanged(const QString &arg1)
         double ang2 = angle * i;
         while (ang2 > 360.) ang2 -= 360.;
         m_phases << ang2;
-        ui->PhaseList->addItem(QString().sprintf("%6.2lf",ang2));
+        ui->PhaseList->addItem(QString("%1").arg(ang2, 6, 'f', 2));
         QListWidgetItem* item = ui->PhaseList->item(i);
         item->setFlags(item->flags() | Qt::ItemIsEditable);
     }
@@ -208,7 +208,7 @@ void PSI_dlg::setPhases(QVector<double> phases){
             ang2 *= 180./M_PI;
 
         QListWidgetItem* item = ui->PhaseList->item(i);
-        item->setText(QString().sprintf("%6.4lf", ang2));
+        item->setText(QString("%1").arg(ang2, 6, 'f', 4));
     }
 
 }
@@ -269,7 +269,7 @@ void PSI_dlg::on_showRadians_clicked(bool checked)
 {
     m_useRadians = checked;
     for(int cnt = 0; cnt < ui->PhaseList->count(); ++cnt){
-        QString txt = QString().sprintf("%6.4lf", m_phases[cnt] * ((checked) ? 1: 180./M_PI));
+        QString txt = QString("%1").arg(m_phases[cnt] * ((checked) ? 1: 180./M_PI), 6, 'f', 4);
         ui->PhaseList->item(cnt)->setText(txt);
     }
     plot(m_phases, m_last_itr,m_last_sdp);
@@ -323,19 +323,19 @@ void PSI_dlg::plot(QVector<double> phases, int iteration, double sdp){
             font.setPointSize ( 12 );
             font.setWeight(QFont::DemiBold);
             p.setFont(font);
-            p.drawText( (x1+x2)/2, (y1+y2)/2,QString().sprintf("% 6.2lf", delta *  k).toStdString().c_str());
+            p.drawText( (x1+x2)/2, (y1+y2)/2,QString("%1").arg(delta *  k, 6, 'f', 2).toStdString().c_str());
             p.setPen(QPen(QColor(100,100,100)));
             font.setPointSize(10);
             p.setFont(font);
-            p.drawText( x2-10,y2+10,QString().sprintf("%d", i+1).toStdString().c_str());
-            p.drawText(x2 + 40, y2 ,QString().sprintf("%6.2lf", angle2 * k).toStdString().c_str());
+            p.drawText( x2-10,y2+10,QString("%1").arg( i+1).toStdString().c_str());
+            p.drawText(x2 + 40, y2 ,QString("%1").arg( angle2 * k, 6, 'f', 2).toStdString().c_str());
             rlast = r;
             r += rdel;
         }
         QFont font=p.font() ;
         font.setPointSize ( 15 );
         p.setFont(font);
-        p.drawText(30,100,QString().sprintf("iteration %i sdp: %lf", iteration, sdp).toStdString().c_str());
+        p.drawText(30,100,QString("iteration %1 sdp: %2").arg(iteration).arg(sdp, 0, 'f').toStdString().c_str());
         p.setPen(QPen(QBrush(QColor(0,0,255)),5));
 
         p.drawLine(50,height -120, 90, height -120);

--- a/psiphasedisplay.cpp
+++ b/psiphasedisplay.cpp
@@ -71,19 +71,19 @@ void PSIphaseDisplay::plot(QVector<double> phases, int iteration, double sdp){
         font.setPointSize ( 12 );
         font.setWeight(QFont::DemiBold);
         p.setFont(font);
-        p.drawText( (x1+x2)/2, (y1+y2)/2,QString().sprintf("% 6.2lf", delta *  k).toStdString().c_str());
+        p.drawText( (x1+x2)/2, (y1+y2)/2,QString("%1").arg(delta *  k, 6, 'f', 2).toStdString().c_str());
         p.setPen(QPen(QColor(100,100,100)));
         font.setPointSize(10);
         p.setFont(font);
-        p.drawText( x2-10,y2+10,QString().sprintf("%d", i+1).toStdString().c_str());
-        p.drawText(x2 + 40, y2 ,QString().sprintf("%6.2lf", angle2 * k).toStdString().c_str());
+        p.drawText( x2-10,y2+10,QString("%1").arg( i+1).toStdString().c_str());
+        p.drawText(x2 + 40, y2 ,QString("%1").arg( angle2 * k, 6, 'f', 2).toStdString().c_str());
         rlast = r;
         r += rdel;
     }
     QFont font=p.font() ;
     font.setPointSize ( 15 );
     p.setFont(font);
-    p.drawText(30,100,QString().sprintf("iteration %i sdp: %lf", iteration, sdp).toStdString().c_str());
+    p.drawText(30,100,QString("iteration %1 sdp: %2").arg(iteration).arg(sdp, 0, 'f').toStdString().c_str());
     p.setPen(QPen(QBrush(QColor(0,0,255)),5));
 
     p.drawLine(50,height -120, 90, height -120);

--- a/psiresizeimagesdlg.cpp
+++ b/psiresizeimagesdlg.cpp
@@ -9,7 +9,7 @@ PSIResizeImagesDlg::PSIResizeImagesDlg(int resize,int max, QWidget *parent) :
     ui->setupUi(this);
     QSettings set;
     ui->m_resize->setMaximum(max);
-    ui->CurrentSize->setText(QString().sprintf("%d",max));
+    ui->CurrentSize->setText(QString("%1").arg(max));
     ui->m_resize->setValue(resize);
 }
 

--- a/settingsprofile.cpp
+++ b/settingsprofile.cpp
@@ -38,7 +38,7 @@ settingsProfile::settingsProfile(QWidget *parent) :
     QSettings set;
     ui->pushButton_1->setStyleSheet(colorButtonStyleSheet(set.value("profile color pushButton_1", QColor(0,0,0).name()).toString()));
     for (int i = 2 ; i < 10; ++i){
-        name = QString().sprintf("pushButton_%d",i);
+        name = QString("pushButton_%1").arg(i);
         QPushButton *btn = findChild<QPushButton *>(name);
         QColor color = QColor(Qt::GlobalColor( 7 + i%7 ) );
         color = QColor(set.value("profile color "+name, color).toString());
@@ -46,13 +46,13 @@ settingsProfile::settingsProfile(QWidget *parent) :
     }
 }
 QColor settingsProfile::getColor(int num){
-    QString name = QString().sprintf("pushButton_%d",1 + num%7);
+    QString name = QString("pushButton_%1").arg(1 + num%7);
     QPushButton *btn = findChild<QPushButton *>(name);
     return btn->palette().color(QPalette::Background);
 }
 
 void settingsProfile::setColor(int num){
-    QString name = QString().sprintf("pushButton_%d",num);
+    QString name = QString("pushButton_%1").arg(num);
     QPushButton *btn = findChild<QPushButton *>(name);
     QColor color = QColorDialog::getColor( btn->palette().color(QPalette::Background));
     btn->setStyleSheet(colorButtonStyleSheet(color));

--- a/showaliasdlg.cpp
+++ b/showaliasdlg.cpp
@@ -87,7 +87,7 @@ showAliasDlg::~showAliasDlg()
      ui->resizedSB->blockSignals(false);
      contrast();
 
-     ui->originalLb->setText( QString().sprintf("Original %dx%d", img.width(),img.height()));
+     ui->originalLb->setText( QString("Original %1x%2").arg(img.width()).arg(img.height()));
      downSize();
 
  }

--- a/simigramdlg.cpp
+++ b/simigramdlg.cpp
@@ -114,13 +114,13 @@ QVariant zTableModel::data(const QModelIndex &index, int role) const
                 int row = index.row();
                 int sr = floor(sqrt(row+1));
 
-                return (QString().sprintf("%d %s", index.row(),
-                      ( sr * sr == index.row()+1)? QString().sprintf("Spherical").toStdString().c_str(): ""));
+                return (QString("%1 %2").arg(index.row()).arg(
+                      ( sr * sr == index.row()+1)? QString("Spherical").toStdString().c_str(): ""));
 
             }
         }
         if (index.column() == 1){
-            return QString().sprintf("%6.3lf",values->at(index.row()));
+            return QString("%1").arg(values->at(index.row()), 6, 'f', 3);
         }
     }
 

--- a/simulationsview.cpp
+++ b/simulationsview.cpp
@@ -642,11 +642,11 @@ void SimulationsView::on_MakePB_clicked()
     QString bestFit = doc.toPlainText();
 
     QString caption = QString("%1   Diameter: %2 ROC: %3 Best Fit CC: %4 Strehl: %5").arg(
-                                        m_wf->name.toStdString().c_str()).arg(
+                                        m_wf->name).arg(
                                         m_wf->diameter, 6, 'f', 1).arg(
                                         m_wf->roc, 6, 'f', 1).arg(
-                                        bestFit.toStdString().c_str()).arg(
-                                        strehl.toStdString().c_str());
+                                        bestFit).arg(
+                                        strehl);
     ui->caption->setText(caption);
     bool wasAliased = false;
 
@@ -711,7 +711,7 @@ void SimulationsView::on_MakePB_clicked()
     cv::Mat focused = computeStarTest(nulledSurface(0), fftSize,  ui->centerMagnifySB->value());
     t = fitStarTest(zoomMat(focused,ui->centerMagnifySB->value()), wid ,gamma/2);
 
-    cv::putText(t,QString("Focused").toStdString(),cv::Point(20,20),1,1,cv::Scalar(255, 255,255));
+    cv::putText(t,"Focused",cv::Point(20,20),1,1,cv::Scalar(255, 255,255));
     QImage focusDisplay ((uchar*)t.data, t.cols, t.rows, t.step, QImage::Format_RGB888);
     ui->Focused->setPixmap(QPixmap::fromImage(focusDisplay.copy()));
 

--- a/simulationsview.cpp
+++ b/simulationsview.cpp
@@ -56,7 +56,7 @@ public:
             return QString("");
 
 
-        return QString().sprintf("%6.2lf",s1 / value);
+        return QString("%1").arg(s1 / value, 6, 'f', 2);
     }
 };
 SimulationsView::SimulationsView(QWidget *parent) :
@@ -126,7 +126,7 @@ void SimulationsView::initMTFPlot(){
 void SimulationsView::setSurface(wavefront *wf){
     m_wf = wf;
     m_arcSecScaleDraw->s1 = (1.22 * 550.e-6/wf->diameter) * 57.3 * 3600;
-    QString txt = QString().sprintf("diameter %6.1lf with max resolution of %6.2lf arcsec",wf->diameter, m_arcSecScaleDraw->s1);
+    QString txt = QString("diameter %1 with max resolution of %2 arcsec").arg(wf->diameter, 6, 'f', 1).arg(m_arcSecScaleDraw->s1, 6, 'f', 2);
    ui->MTF->setAxisTitle(QwtPlot::xBottom,txt);
     if (wf == 0 ){
         needs_drawing = false;
@@ -503,7 +503,7 @@ void SimulationsView::on_film_clicked()
         QApplication::processEvents();
         on_MakePB_clicked();
         QApplication::processEvents();
-        QString name = QString().sprintf("/frame%03d",cnt++);
+        QString name = QString("/frame%1").arg(cnt++, 3 ,10, QLatin1Char('0'));
 
         saveImage(filmDir+name);
     }
@@ -641,11 +641,11 @@ void SimulationsView::on_MakePB_clicked()
     doc.setHtml(metrics->mCC->text());
     QString bestFit = doc.toPlainText();
 
-    QString caption = QString().sprintf("%s   Diameter: %6.1lf ROC: %6.1lf Best Fit CC: %s Strehl: %s",
-                                        m_wf->name.toStdString().c_str(),
-                                        m_wf->diameter,
-                                        m_wf->roc,
-                                        bestFit.toStdString().c_str(),
+    QString caption = QString("%1   Diameter: %2 ROC: %3 Best Fit CC: %4 Strehl: %5").arg(
+                                        m_wf->name.toStdString().c_str()).arg(
+                                        m_wf->diameter, 6, 'f', 1).arg(
+                                        m_wf->roc, 6, 'f', 1).arg(
+                                        bestFit.toStdString().c_str()).arg(
                                         strehl.toStdString().c_str());
     ui->caption->setText(caption);
     bool wasAliased = false;
@@ -664,13 +664,13 @@ void SimulationsView::on_MakePB_clicked()
         stalkWidth = m_wf->m_outside.m_radius * .1;
         theObstruction = make_obstructionMask(m_wf->workMask);
         m_wf->workMask = theObstruction.clone();
-        showData(QString().sprintf("%f",m_wf->diameter).toStdString().c_str(), theObstruction.clone(), false);
+        showData(QString("%1").arg(m_wf->diameter, 0, 'f').toStdString().c_str(), theObstruction.clone(), false);
 
     }
 
     cv::Mat inside = computeStarTest(nulledSurface(-defocus), fftSize, 3);
     cv::Mat t = fitStarTest(inside, wid,gamma);
-    cv::putText(t,QString().sprintf("-%5.1lf waves inside",2 * defocus).toStdString(),cv::Point(50,30),1,1,cv::Scalar(255, 255,255));
+    cv::putText(t,QString("-%1 waves inside").arg(2 * defocus, 5, 'f', 1).toStdString(),cv::Point(50,30),1,1,cv::Scalar(255, 255,255));
     wasAliased |= alias;
     if (alias)
     {
@@ -687,7 +687,7 @@ void SimulationsView::on_MakePB_clicked()
     // outside focus star test
     cv::Mat outside = computeStarTest(nulledSurface(defocus),fftSize,3);
     t = fitStarTest(outside,wid ,gamma);
-    cv::putText(t,QString().sprintf("%5.1lfwaves outside",2 * defocus).toStdString(),cv::Point(50,30),1,1,cv::Scalar(255, 255,255));
+    cv::putText(t,QString("%1waves outside").arg(2 * defocus, 5, 'f', 1).toStdString(),cv::Point(50,30),1,1,cv::Scalar(255, 255,255));
     wasAliased |= alias;
     if (alias)
     {
@@ -711,7 +711,7 @@ void SimulationsView::on_MakePB_clicked()
     cv::Mat focused = computeStarTest(nulledSurface(0), fftSize,  ui->centerMagnifySB->value());
     t = fitStarTest(zoomMat(focused,ui->centerMagnifySB->value()), wid ,gamma/2);
 
-    cv::putText(t,QString().sprintf("Focused").toStdString(),cv::Point(20,20),1,1,cv::Scalar(255, 255,255));
+    cv::putText(t,QString("Focused").toStdString(),cv::Point(20,20),1,1,cv::Scalar(255, 255,255));
     QImage focusDisplay ((uchar*)t.data, t.cols, t.rows, t.step, QImage::Format_RGB888);
     ui->Focused->setPixmap(QPixmap::fromImage(focusDisplay.copy()));
 

--- a/standastigwizard.cpp
+++ b/standastigwizard.cpp
@@ -298,8 +298,8 @@ void define_input::browse(){
         CounterRotationDlg dlg( fileName,rot, true);
         dlg.setCCW(CCWRb->isChecked());
         if (dlg.exec()) {
-            QString b = QString("%1,%2,%3").arg(fileName.toStdString().c_str()).arg((dlg.isClockwise()) ? "CW" : "CCW").arg(
-                                          dlg.getRotation().toStdString().c_str());
+            QString b = QString("%1,%2,%3").arg(fileName).arg((dlg.isClockwise()) ? "CW" : "CCW").arg(
+                                          dlg.getRotation());
             new QListWidgetItem(b,listDisplay);
             rotationDef *rd = new rotationDef(fileName, (dlg.isClockwise() ? 1 : -1) * dlg.getRotation().toDouble());
             rotationList.append(rd);

--- a/standastigwizard.cpp
+++ b/standastigwizard.cpp
@@ -298,7 +298,7 @@ void define_input::browse(){
         CounterRotationDlg dlg( fileName,rot, true);
         dlg.setCCW(CCWRb->isChecked());
         if (dlg.exec()) {
-            QString b = QString().sprintf("%s,%s,%s", fileName.toStdString().c_str(),(dlg.isClockwise()) ? "CW" : "CCW",
+            QString b = QString("%1,%2,%3").arg(fileName.toStdString().c_str()).arg((dlg.isClockwise()) ? "CW" : "CCW").arg(
                                           dlg.getRotation().toStdString().c_str());
             new QListWidgetItem(b,listDisplay);
             rotationDef *rd = new rotationDef(fileName, (dlg.isClockwise() ? 1 : -1) * dlg.getRotation().toDouble());

--- a/surfacemanager.cpp
+++ b/surfacemanager.cpp
@@ -289,7 +289,7 @@ public:
         st *= st;
         const double  e = 2.7182818285;
         double strl = pow(e,-st);
-        return QString().sprintf("%6.3lf",strl);
+        return QString("%1").arg(strl, 6, 'f', 3);
     }
 };
 
@@ -698,7 +698,7 @@ void SurfaceManager::ObstructionChanged(){
 void SurfaceManager::centerMaskValue(int val){
     insideOffset = val;
     double mmPerPixel = getCurrent()->diameter/(2 *( m_wavefronts[m_currentNdx]->m_outside.m_radius-1));
-    m_surfaceTools->m_centerMaskLabel->setText(QString().sprintf("%6.2lf mm",mmPerPixel* val));
+    m_surfaceTools->m_centerMaskLabel->setText(QString("%1 mm").arg(mmPerPixel* val, 6, 'f', 2));
     makeMask(m_currentNdx);
     wavefront *wf = m_wavefronts[m_currentNdx];
     wf->dirtyZerns = true;
@@ -711,7 +711,7 @@ void SurfaceManager::centerMaskValue(int val){
 void SurfaceManager::outsideMaskValue(int val){
     outsideOffset = val;
     double mmPerPixel = m_wavefronts[m_currentNdx]->diameter/(2 * (m_wavefronts[m_currentNdx]->m_outside.m_radius));
-    m_surfaceTools->m_edgeMaskLabel->setText(QString().sprintf("%6.2lf mm",mmPerPixel* val));
+    m_surfaceTools->m_edgeMaskLabel->setText(QString("%1 mm").arg(mmPerPixel* val, 6, 'f', 2));
     makeMask(m_currentNdx);
     wavefront *wf = m_wavefronts[m_currentNdx];
     wf->dirtyZerns = true;
@@ -765,7 +765,7 @@ void SurfaceManager::waveFrontClickedSlot(int ndx)
 {
 
     m_currentNdx = ndx;
-    QString msg = QString().sprintf(" %dx%d ",m_wavefronts[ndx]->data.cols, m_wavefronts[ndx]->data.rows);
+    QString msg = QString(" %1x%2 ").arg(m_wavefronts[ndx]->data.cols).arg(m_wavefronts[ndx]->data.rows);
     ((MainWindow*)parent())->statusBar()->showMessage(msg);
     sendSurface(m_wavefronts[ndx]);
 }
@@ -797,7 +797,7 @@ void SurfaceManager::surfaceSmoothGBValue(double value){
     m_gbValue = value;
     mirrorDlg *md = mirrorDlg::get_Instance();
 
-    m_surfaceTools->setBlurText(QString().sprintf("%6.2lf mm", .01 * value * md->diameter));
+    m_surfaceTools->setBlurText(QString("%1 mm").arg( .01 * value * md->diameter, 6, 'f', 2));
     if (m_wavefronts.size() == 0)
         return;
 
@@ -820,7 +820,7 @@ void SurfaceManager::surfaceSmoothGBEnabled(bool b){
 
     mirrorDlg *md = ((MainWindow*)parent())->m_mirrorDlg;
     double mmPerPixel = md->diameter/(2 * rad);
-    m_surfaceTools->setBlurText(QString().sprintf("%6.2lf mm",m_gbValue* mmPerPixel));
+    m_surfaceTools->setBlurText(QString("%1 mm").arg(m_gbValue* mmPerPixel, 6, 'f', 2));
     if (m_wavefronts.size() == 0)
         return;
     //emit generateSurfacefromWavefront(m_currentNdx, this);
@@ -1148,8 +1148,8 @@ wavefront * SurfaceManager::readWaveFront(QString fileName, bool mirrorParamsCha
     if (lambda != md->lambda){
         if (lambdResp == ASK){
             QString message("The interferogram wavelength (");
-            message += QString().sprintf("%6.3lf", lambda) +
-                    ") Of the wavefront does not match the config value of " + QString().sprintf("%6.3lf\n",md->lambda) +
+            message += QString("%1").arg( lambda, 6, 'f', 3) +
+                    ") Of the wavefront does not match the config value of " + QString("%1\n").arg(md->lambda, 6, 'f', 3) +
                     "Do you want to make the config match?";
 
 
@@ -1177,8 +1177,8 @@ wavefront * SurfaceManager::readWaveFront(QString fileName, bool mirrorParamsCha
     if (roundl(diam * 10) != roundl(md->diameter* 10))
     {
         QString message("The mirror diameter (");
-        message += QString().sprintf("%6.3lf",diam) +
-                ") Of the wavefront does not match the config value of " + QString().sprintf("%6.3lf\n",md->diameter) +
+        message += QString("%1").arg(diam, 6, 'f', 3) +
+                ") Of the wavefront does not match the config value of " + QString("%1\n").arg(md->diameter, 6, 'f', 3) +
                 "Do you want to make the config match?";
         if (diamResp == ASK){
             int resp = QMessageBox(QMessageBox::Information,"config", message,QMessageBox::Yes|QMessageBox::No |
@@ -1206,8 +1206,8 @@ wavefront * SurfaceManager::readWaveFront(QString fileName, bool mirrorParamsCha
     if (roundl(roc * 10.) != roundl(md->roc * 10.))
     {
         QString message("The mirror roc (");
-        message += QString().sprintf("%6.3lf",roc) +
-                ") Of the wavefront does not match the config value of " + QString().sprintf("%6.3lf\n",md->roc) +
+        message += QString("%1").arg(roc, 6, 'f', 3) +
+                ") Of the wavefront does not match the config value of " + QString("%1\n").arg(md->roc, 6, 'f', 3) +
                 "Do you want to make the config match?";
         //qDebug() << message;
         if (rocResp == ASK){
@@ -2133,14 +2133,14 @@ qDebug() << "circle fit"<< avgRadius << fittedcircle1.r << fittedcircle2.r;
         wf->useSANull = false;
         wf->min = smin;
         wf->max =  smax;
-        wf->name = QString().sprintf("%06.2lf",list[i]->angle);
+        wf->name = QString("%1").arg(list[i]->angle, 6, 'f', 2, QLatin1Char('0'));
 
         cp->setSurface(wf);
         cp->resize(Width,Height);
         cp->replot();
         contour.fill( QColor( Qt::white ).rgb() );
         renderer.render( cp, &painter, QRect(0,0,Width,Height) );
-        QString imageName = QString().sprintf("mydata://zern%s.png",wf->name.toStdString().c_str());
+        QString imageName = QString("mydata://zern%1.png").arg(wf->name.toStdString().c_str());
         imageName.replace("-","CCW");
         doc->addResource(QTextDocument::ImageResource,  QUrl(imageName), QVariant(contour));
         results.res.append (imageName);
@@ -2349,9 +2349,9 @@ void SurfaceManager::computeStandAstig(define_input *wizPage, QList<rotationDef 
             if (!found){
                 if (QMessageBox::Yes ==
                   QMessageBox::question(0, tr("Error"),
-                                     QString().sprintf("No 90 deg pair for %s and angle %6.2lf",
-                                                       lookat[i]->fname.toStdString().c_str(),
-                                                       lookat[i]->angle))){
+                                     QString("No 90 deg pair for %1 and angle %2").arg(
+                                                       lookat[i]->fname.toStdString().c_str()).arg(
+                                                       lookat[i]->angle, 6, 'f', 2))){
                         wizPage->runpb->setText("compute");
                         wizPage->runpb->setEnabled(true);
                         return;
@@ -2427,8 +2427,8 @@ void SurfaceManager::computeStandAstig(define_input *wizPage, QList<rotationDef 
         plot->replot();
         renderer.render( plot, &painter, QRect(0,0,contourWidth,contourHeight) );
 
-        QString imageName = QString().sprintf("mydata://%s.png",list[i]->fname.toStdString().c_str());
-        QString angle = QString().sprintf("%6.2lf Deg",-list[i]->angle);
+        QString imageName = QString("mydata://%1.png").arg(list[i]->fname.toStdString().c_str());
+        QString angle = QString("%1 Deg").arg(-list[i]->angle, 6, 'f', 2);
         doc->addResource(QTextDocument::ImageResource,  QUrl(imageName), QVariant(contour));
         doc1Res.append(imageName);
         html.append("<tr><td><p align='center'> <img src='" +imageName + "' /><br><b>" + angle + "</b></p></td>");
@@ -2451,8 +2451,8 @@ void SurfaceManager::computeStandAstig(define_input *wizPage, QList<rotationDef 
 
         contour.fill( QColor( Qt::white ).rgb() );
         renderer.render( plot, &painter, QRect(0,0,contourWidth,contourHeight) );
-        angle = QString().sprintf("%6.2lf Deg",-list[i]->angle);
-        imageName = QString().sprintf("mydata://CR%s%s.png",list[i]->fname.toStdString().c_str(),angle.toStdString().c_str());
+        angle = QString("%1 Deg").arg(-list[i]->angle, 6, 'f', 2);
+        imageName = QString("mydata://CR%1%2.png").arg(list[i]->fname.toStdString().c_str()).arg(angle.toStdString().c_str());
 
         doc->addResource(QTextDocument::ImageResource,  QUrl(imageName), QVariant(contour));
         doc1Res.append(imageName);
@@ -2736,10 +2736,10 @@ void SurfaceManager::report(){
             "<table border='1' width = '100%'><tr><td>" + Diameter + " mm</td><td>" + ROC + " mm</td>"
             "<td>" +FNumber+ "</td></tr>"
             "<tr><td> RMS: " + QString().number(wf->std,'f',3) +
-                QString().sprintf(" waves at %6.1lf nm</td><td>Strehl: ",outputLambda) + metrics->mStrehl->text() +
+                QString(" waves at %1 nm</td><td>Strehl: ").arg(outputLambda, 6, 'f', 1) + metrics->mStrehl->text() +
             "</td><td>" + BFC + "</td></tr>"
             "<tr><td>" + ((md->isEllipse()) ? "":"Desired Conic: " + QString::number(md->cc)) + "</td><td>" +
-            ((md->doNull) ? QString().sprintf("SANull: %6.4lf",md->z8 * md->cc) : "No software Null") + "</td>"
+            ((md->doNull) ? QString("SANull: %1").arg(md->z8 * md->cc, 6, 'f', 4) : "No software Null") + "</td>"
             "<td>Waves per fringe: " + QString::number(md->fringeSpacing) + "<br>Interferogram Wave length: "+ QString::number(md->lambda) + "nm</td></tr>"
             "</table></p>";
 
@@ -2763,8 +2763,8 @@ void SurfaceManager::report(){
             }
 
 
-            zerns.append("<tr><td>" + QString(zernsNames[i]) + "</td><td><table width = '100%'><tr><td>" + QString().sprintf("%6.3lf </td><td>%6.3lf</td></tr></table>",
-                             val, computeRMS(i,val)) + "</td><td>" +
+            zerns.append("<tr><td>" + QString(zernsNames[i]) + "</td><td><table width = '100%'><tr><td>" + QString("%1 </td><td>%2</td></tr></table>").arg(
+                             val, 6, 'f', 3).arg(computeRMS(i,val), 6, 'f', 3) + "</td><td>" +
                          QString((enabled) ? QString("") : QString("Disabled")) + "</td></tr>");
             if (i == 5){
                 double x = wf->InputZerns[4];
@@ -2773,8 +2773,8 @@ void SurfaceManager::report(){
                 double angle = atan2(y,x)/2;
 
                 zerns.append("<tr><td>astig Polar</td><td><table width = '100%'><tr><td>"
-                             + QString().sprintf("%6.3lf </td><td>%6.3lf Deg.</td></tr></table>",
-                                 mag, angle * (180.0 / M_PI)) + "</td><td>" +
+                             + QString("%1 </td><td>%1 Deg.</td></tr></table>").arg(
+                                 mag, 6, 'f', 3).arg(angle * (180.0 / M_PI), 6, 'f', 3) + "</td><td>" +
                              QString((enabled) ? QString("") : QString("Disabled")) + "</td></tr>");
             }
         }
@@ -2787,8 +2787,8 @@ void SurfaceManager::report(){
 
         for (int i = half; i < Z_TERMS; ++i){
             double val = wf->InputZerns[i];
-            zerns.append("<tr><td>" + QString(zernsNames[i]) + "</td><td><table width = '100%'><tr><td>" + QString().sprintf("%6.3lf</td><td>%6.3lf</td></tr></table>"
-                                                                                                                             ,val, computeRMS(i,val)) + "</td><td>" +
+            zerns.append("<tr><td>" + QString(zernsNames[i]) + "</td><td><table width = '100%'><tr><td>" + QString("%1</td><td>%1</td></tr></table>").arg(
+                                                                                                                             val, 6, 'f', 3).arg(computeRMS(i,val), 6, 'f', 3) + "</td><td>" +
                          QString((zernEnables[i]) ? QString("") : QString("Disabled")) + "</td></tr>");
         }
         zerns.append("</table></td></tr></table></p>");
@@ -3168,7 +3168,7 @@ void SurfaceManager::tiltAnalysis(){
    pl1->insertLegend( new QwtLegend() , QwtPlot::TopLegend);
    pl1->setAxisTitle( QwtPlot::yLeft, "astig" );
    pl1->setAxisTitle(QwtPlot::xBottom, "tilt");
-   pl1->setTitle(QString().sprintf("tilt vs Astig %d samples", xvals.length()));
+   pl1->setTitle(QString("tilt vs Astig %1 samples").arg(xvals.length()));
    QwtPlotGrid *grid = new QwtPlotGrid();
    grid->attach(pl1);
    QwtPlotCurve *xTilt = new QwtPlotCurve("X");

--- a/surfacemanager.cpp
+++ b/surfacemanager.cpp
@@ -1647,10 +1647,8 @@ void SurfaceManager::rotateThese(double angle, QList<int> list){
     pd->setRange(0, list.size());
     for (int i = 0; i < list.size(); ++i) {
         wavefront *oldWf = m_wavefronts[list[i]];
-        QString newName;
         QStringList l = oldWf->name.split('.');
-        newName.sprintf("%s_%s%05.1lf",l[0].toStdString().c_str(), (angle >= 0) ? "CW":"CCW", fabs(angle) );
-        newName += ".wft";
+        QString newName = QString("%1_%2%3.wft").arg(l[0]).arg((angle >= 0) ? "CW":"CCW").arg(fabs(angle), 5, 'f', 1, QLatin1Char('0'));
         wavefront *wf = new wavefront();
         *wf = *m_wavefronts[list[0]];
         //emit nameChanged(wf->name, newName);
@@ -2140,7 +2138,7 @@ qDebug() << "circle fit"<< avgRadius << fittedcircle1.r << fittedcircle2.r;
         cp->replot();
         contour.fill( QColor( Qt::white ).rgb() );
         renderer.render( cp, &painter, QRect(0,0,Width,Height) );
-        QString imageName = QString("mydata://zern%1.png").arg(wf->name.toStdString().c_str());
+        QString imageName = QString("mydata://zern%1.png").arg(wf->name);
         imageName.replace("-","CCW");
         doc->addResource(QTextDocument::ImageResource,  QUrl(imageName), QVariant(contour));
         results.res.append (imageName);
@@ -2427,7 +2425,7 @@ void SurfaceManager::computeStandAstig(define_input *wizPage, QList<rotationDef 
         plot->replot();
         renderer.render( plot, &painter, QRect(0,0,contourWidth,contourHeight) );
 
-        QString imageName = QString("mydata://%1.png").arg(list[i]->fname.toStdString().c_str());
+        QString imageName = QString("mydata://%1.png").arg(list[i]->fname);
         QString angle = QString("%1 Deg").arg(-list[i]->angle, 6, 'f', 2);
         doc->addResource(QTextDocument::ImageResource,  QUrl(imageName), QVariant(contour));
         doc1Res.append(imageName);
@@ -2452,7 +2450,7 @@ void SurfaceManager::computeStandAstig(define_input *wizPage, QList<rotationDef 
         contour.fill( QColor( Qt::white ).rgb() );
         renderer.render( plot, &painter, QRect(0,0,contourWidth,contourHeight) );
         angle = QString("%1 Deg").arg(-list[i]->angle, 6, 'f', 2);
-        imageName = QString("mydata://CR%1%2.png").arg(list[i]->fname.toStdString().c_str()).arg(angle.toStdString().c_str());
+        imageName = QString("mydata://CR%1%2.png").arg(list[i]->fname).arg(angle);
 
         doc->addResource(QTextDocument::ImageResource,  QUrl(imageName), QVariant(contour));
         doc1Res.append(imageName);

--- a/surfacemanager.cpp
+++ b/surfacemanager.cpp
@@ -2773,7 +2773,7 @@ void SurfaceManager::report(){
                 double angle = atan2(y,x)/2;
 
                 zerns.append("<tr><td>astig Polar</td><td><table width = '100%'><tr><td>"
-                             + QString("%1 </td><td>%1 Deg.</td></tr></table>").arg(
+                             + QString("%1 </td><td>%2 Deg.</td></tr></table>").arg(
                                  mag, 6, 'f', 3).arg(angle * (180.0 / M_PI), 6, 'f', 3) + "</td><td>" +
                              QString((enabled) ? QString("") : QString("Disabled")) + "</td></tr>");
             }
@@ -2787,7 +2787,7 @@ void SurfaceManager::report(){
 
         for (int i = half; i < Z_TERMS; ++i){
             double val = wf->InputZerns[i];
-            zerns.append("<tr><td>" + QString(zernsNames[i]) + "</td><td><table width = '100%'><tr><td>" + QString("%1</td><td>%1</td></tr></table>").arg(
+            zerns.append("<tr><td>" + QString(zernsNames[i]) + "</td><td><table width = '100%'><tr><td>" + QString("%1</td><td>%2</td></tr></table>").arg(
                                                                                                                              val, 6, 'f', 3).arg(computeRMS(i,val), 6, 'f', 3) + "</td><td>" +
                          QString((zernEnables[i]) ? QString("") : QString("Disabled")) + "</td></tr>");
         }

--- a/unwraperrorsview.cpp
+++ b/unwraperrorsview.cpp
@@ -40,7 +40,7 @@ void unwrapErrorsView::createUnwrapErrors(){
         }
     }
 
-    ui->count->setText(QString().sprintf("%d",cnt));
+    ui->count->setText(QString("%1").arg(cnt));
     Mat xxx;
     flip(errorView, xxx, 0);
 

--- a/usercolormapdlg.cpp
+++ b/usercolormapdlg.cpp
@@ -58,19 +58,18 @@ std::cout <<" main2";
 
     stops.clear();
 
-    QString sx = QString().sprintf("userColorStopColor%02d",10);
     for (int i = 0; i < 11; ++i){
-        double pos = set.value(QString().sprintf("userColorStopPos%02d", i), (double)i * .1).toDouble();
+        double pos = set.value(QString("userColorStopPos%1").arg(i, 2, 10, QLatin1Char('0')), (double)i * .1).toDouble();
 
-        QColor c = QColor(set.value(QString().sprintf("userColorStopColor%02d", i), plotColors[i%10]).toString());
+        QColor c = QColor(set.value(QString("userColorStopColor%1").arg(i, 2, 10, QLatin1Char('0')), plotColors[i%10]).toString());
 
         stops << colorStop(pos,c);
 
-        QCheckBox * cb = findChild<QCheckBox *>(QString().sprintf("cb%02d",i));
+        QCheckBox * cb = findChild<QCheckBox *>(QString("cb%1").arg(i, 2, 10, QLatin1Char('0')));
         if (cb) {
-            cb->setChecked(set.value(QString().sprintf("userColorStopEnable%02d",i), 1).toBool());
+            cb->setChecked(set.value(QString("userColorStopEnable%1").arg(i, 2, 10, QLatin1Char('0')), 1).toBool());
         }
-        QPushButton * pb = findChild<QPushButton *>(QString().sprintf("pb%02d",i));
+        QPushButton * pb = findChild<QPushButton *>(QString("pb%1").arg(i, 2, 10, QLatin1Char('0')));
         if (pb){
             QString s ="background-color: #" + QString::number(stops[i].color.rgb(), 16).toUpper();
             pb->setStyleSheet(s);
@@ -113,7 +112,7 @@ void userColorMapDlg::setColorMap(){
         //stopList << stops[0];
     }
     for (int i = 0; i < 12; ++i){
-        QCheckBox * cb = findChild<QCheckBox *>(QString().sprintf("cb%02d",i));
+        QCheckBox * cb = findChild<QCheckBox *>(QString("cb%1").arg(i, 2, 10, QLatin1Char('0')));
         if (cb && cb->isChecked()) {
             colorStop s(((m_reverse)? stops[10 - i].pos : stops[i].pos), stops[i].color);
             stopList << s;
@@ -401,7 +400,7 @@ void userColorMapDlg::on_savePb_clicked()
     for(int i = 0; i < stops.size(); ++i){
 
         file << i << "," << stops[i].pos << "," << stops[i].color.name().toStdString().c_str() << ",";
-        QString s = QString().sprintf("cb%02d",i);
+        QString s = QString("cb%1").arg(i, 2, 10, QLatin1Char('0'));
         QCheckBox *cb = findChild<QCheckBox *>(s);
         if (cb && cb->isChecked())
             file << "checked";
@@ -432,15 +431,15 @@ void userColorMapDlg::on_loadPb_clicked()
           int ndx = parms[0].toInt();
           colorStop s(parms[1].toDouble(), QColor(parms[2]));
           stops[parms[0].toInt()] = s;
-          QPushButton * pb = findChild<QPushButton *>(QString().sprintf("pb%02d",ndx));
+          QPushButton * pb = findChild<QPushButton *>(QString("pb%1").arg(ndx, 2, 10, QLatin1Char('0')));
           if (pb && ndx < 12){
               QString s ="background-color: #" + QString::number(stops[ndx].color.rgb(), 16).toUpper();
               pb->setStyleSheet(s);
               pb->update();
               QSettings set;
-              set.setValue(QString().sprintf("userColorStopColor%02d",ndx), QColor(parms[2]).name());
+              set.setValue(QString("userColorStopColor%1").arg(ndx, 2, 10, QLatin1Char('0')), QColor(parms[2]).name());
           }
-          QCheckBox * cb = findChild<QCheckBox *>(QString().sprintf("cb%02d",ndx));
+          QCheckBox * cb = findChild<QCheckBox *>(QString("cb%1").arg(ndx, 2, 10, QLatin1Char('0')));
           if (cb) {
               cb->setChecked(parms[3] == "checked");
 

--- a/utilil.cpp
+++ b/utilil.cpp
@@ -12,18 +12,18 @@ long showmem(QString /*title*/){
     statex.dwLength = sizeof (statex);
     GlobalMemoryStatusEx (&statex);
          return statex.ullAvailVirtual/DIV;
-    qDebug() <<QString().sprintf("%*ld%% in use.", WIDTH, statex.dwMemoryLoad);
+    qDebug() <<QString("%1%% in use.").arg(statex.dwMemoryLoad, WIDTH);
 
-     qDebug() <<QString().sprintf ("%*lld free  MB of physical memory.",
-              WIDTH, statex.ullAvailPhys/DIV);
+     qDebug() <<QString("%1 free  MB of physical memory.").arg(
+              statex.ullAvailPhys/DIV, WIDTH);
 
 
-     qDebug() <<QString().sprintf ("%*lld free  MB of paging file.",
-              WIDTH, statex.ullAvailPageFile/DIV);
-     qDebug() <<QString().sprintf ("%*lld total MB of virtual memory.",
-              WIDTH, statex.ullTotalVirtual/DIV);
-     qDebug() <<QString().sprintf("%*lld free  MB of virtual memory.",
-              WIDTH, statex.ullAvailVirtual/DIV);
+     qDebug() <<QString("%1 free  MB of paging file.").arg(
+              statex.ullAvailPageFile/DIV, WIDTH);
+     qDebug() <<QString("%1 total MB of virtual memory.").arg(
+              statex.ullTotalVirtual/DIV, WIDTH);
+     qDebug() <<QString("%1 free  MB of virtual memory.").arg(
+              statex.ullAvailVirtual/DIV, WIDTH);
 
      return statex.ullAvailVirtual/DIV;
 }

--- a/utilil.cpp
+++ b/utilil.cpp
@@ -12,7 +12,7 @@ long showmem(QString /*title*/){
     statex.dwLength = sizeof (statex);
     GlobalMemoryStatusEx (&statex);
          return statex.ullAvailVirtual/DIV;
-    qDebug() <<QString("%1%% in use.").arg(statex.dwMemoryLoad, WIDTH);
+    qDebug() <<QString("%1% in use.").arg(statex.dwMemoryLoad, WIDTH);
 
      qDebug() <<QString("%1 free  MB of physical memory.").arg(
               statex.ullAvailPhys/DIV, WIDTH);

--- a/vortexdebug.cpp
+++ b/vortexdebug.cpp
@@ -40,7 +40,7 @@ void vortexDebug::on_showInput_clicked(bool checked)
 void vortexDebug::on_smooth_valueChanged(int value)
 {
     m_smooth = value;
-    ui->label->setText(QString().sprintf("%d",value));
+    ui->label->setText(QString("%1").arg(value));
 
 }
 

--- a/wftstats.cpp
+++ b/wftstats.cpp
@@ -69,7 +69,7 @@ public:
         st *= st;
         const double  e = 2.7182818285;
         double strl = pow(e,-st);
-        return QString().sprintf("%6.3lf",strl);
+        return QString("%1").arg(strl, 6, 'f', 3);
     }
 };
 
@@ -425,7 +425,7 @@ QwtPlot *wftStats::makeWftPlot(QVector<wavefront *> &wavefronts, int ndx){
     grid->setMinorPen( Qt::gray, 0 , Qt::DotLine );
     grid->enableYMin(true);
     grid->attach(wftPlot);
-    QwtPlotCurve *runingavg = new QwtPlotCurve(QString().sprintf("RMS of Running Average of wavefronts"));
+    QwtPlotCurve *runingavg = new QwtPlotCurve(QString("RMS of Running Average of wavefronts"));
     runingavg->setSamples(avgPoints);
     runingavg->setRenderHint( QwtPlotItem::RenderAntialiased, true );
     runingavg->setPen(Qt::blue,2);
@@ -436,7 +436,7 @@ QwtPlot *wftStats::makeWftPlot(QVector<wavefront *> &wavefronts, int ndx){
                                        12,12,13,13,14,14,15,15,16,16,17};
 
         for (int zern = zernToCombinedNx[zernFrom]; zern <= zernToCombinedNx[zernTo]; ++zern){
-            QwtPlotCurve *zcurve = new QwtPlotCurve(QString().sprintf("%s",zNames[zern].toStdString().c_str()));
+            QwtPlotCurve *zcurve = new QwtPlotCurve(zNames[zern]);
             QPolygonF points;
             int cnt = 0;
             foreach(double v, zerns[zern]){

--- a/zernikedlg.cpp
+++ b/zernikedlg.cpp
@@ -109,22 +109,22 @@ QVariant ZernTableModel::data(const QModelIndex &index, int role) const
                 int row = index.row();
                 int sr = floor(sqrt(row+1));
 
-                return (QString().sprintf("%d %s", index.row(),
-                      ( sr * sr == index.row()+1)? QString().sprintf("Spherical").toStdString().c_str(): ""));
+                return (QString("%1 %2").arg(index.row()).arg(
+                      ( sr * sr == index.row()+1)? "Spherical" : ""));
             }
         }
         if (index.column() == 1){
             if (index.row() == 3 && surfaceAnalysisTools::get_Instance()->m_useDefocus){
-                return QString().sprintf("%6.3lf",surfaceAnalysisTools::get_Instance()->m_defocus);
+                return QString("%1").arg(surfaceAnalysisTools::get_Instance()->m_defocus, 6, 'f', 3);
             }
 
             mirrorDlg &md = *mirrorDlg::get_Instance();
             if (index.row() == 8 && md.doNull && !m_nulled){
                 double val = values[8] - md.z8 * md.cc;
-                return QString().sprintf("%6.3lf  %6.3lf",val, computeRMS(8, val));
+                return QString("%1  %2").arg(val, 6, 'f', 3).arg( computeRMS(8, val), 6, 'f', 3);
             }
 
-            return QString().sprintf("%6.3lf  %6.3lf",values[index.row()], computeRMS(index.row(), values[index.row()]));
+            return QString("%1  %2").arg(values[index.row()], 6, 'f', 3).arg(computeRMS(index.row(), values[index.row()]), 6, 'f', 3);
         }
     }
     if (role == Qt::CheckStateRole){

--- a/zernikeeditdlg.cpp
+++ b/zernikeeditdlg.cpp
@@ -19,7 +19,7 @@ zernikeEditDlg::zernikeEditDlg(SurfaceManager * sfm, QWidget *parent) :
     QSettings set;
     m_maxOrder = set.value("Zern maxOrder", 10).toInt();
     ui->maxOrder->setValue(m_maxOrder);
-    ui->numberOfTerms->setText(QString().sprintf("%d Terms",m_noOfTerms));
+    ui->numberOfTerms->setText(QString("%1 Terms").arg(m_noOfTerms));
 
 }
 
@@ -172,7 +172,7 @@ void zernikeEditDlg::on_maxOrder_valueChanged(int arg1)
     zernikeProcess &zp = *zernikeProcess::get_Instance();
     zp.setMaxOrder(arg1);
     m_noOfTerms = zp.getNumberOfTerms();
-    ui->numberOfTerms->setText(QString().sprintf("%d Terms",m_noOfTerms));
+    ui->numberOfTerms->setText(QString("%1 Terms").arg(m_noOfTerms));
     tableModel->resizeRows(m_noOfTerms);
     emit termCountChanged(m_noOfTerms);
 }

--- a/zernikeprocess.cpp
+++ b/zernikeprocess.cpp
@@ -696,7 +696,7 @@ void zernikeProcess::unwrap_to_zernikes(wavefront &wf, int zterms){
                 if (useSvd){
                     B(sampleCnt++) = surface.at<double>(y,x);
                     if (sampleCnt > count){
-                        QMessageBox::warning(0,"Critical Error", QString().sprintf("Zernike computation sampleCnt > count %d %d",sampleCnt,count));
+                        QMessageBox::warning(0,"Critical Error", QString("Zernike computation sampleCnt > count %1 %2").arg(sampleCnt).arg(count));
                         return ;
                     }
                 }
@@ -710,7 +710,7 @@ void zernikeProcess::unwrap_to_zernikes(wavefront &wf, int zterms){
 
         double conditionNumber = 1./cv::invert(A,Ai,DECOMP_SVD);
         double c2 = cv::norm(A,NORM_L2) * cv::norm(Ai,NORM_L2);
-        emit statusBarUpdate(QString().sprintf(" Zernike LSF matrix Condition Numbers %6.3lf %6.3lf", conditionNumber, c2),1);
+        emit statusBarUpdate(QString(" Zernike LSF matrix Condition Numbers %1 %2").arg(conditionNumber, 6, 'f', 3).arg(c2, 6, 'f', 3),1);
     }
     wf.InputZerns = std::vector<double>(zterms,0);
     for (int z = 0; z < X.rows; ++z){
@@ -1322,14 +1322,14 @@ void dumpArma(arma::mat mm, QString title = "", QVector<QString> colHeading = QV
         if (!RowLable.empty()){
 
             if (row < RowLable.size()){
-                log.append(QString().sprintf("<b>%s</b>",RowLable[row].toStdString().c_str()));
+                log.append(QString("<b>%1</b>").arg(RowLable[row].toStdString().c_str()));
             }
 
         }
         log.append("</td>");
 
         for (int c = 0; c< 10; ++c){
-            log.append(QString().sprintf("<td style=\"text-align:center\" width=\"150\">%6.5lf</td>",theMat(row,c)));
+            log.append(QString("<td style=\"text-align:center\" width=\"150\">%1</td>").arg(theMat(row,c), 6, 'f', 5));
         }
         log.append("</tr>\n");
 
@@ -1431,7 +1431,7 @@ std::vector<double>  zernikeProcess::ZernFitWavefront(wavefront &wf){
 
     int sampleCnt = 0;
     QProgressDialog *prg = new QProgressDialog;
-    prg->setWindowTitle(QString().sprintf("fitting %d samples to %d zernike terms",m_rhoTheta.n_cols,getNumberOfTerms()));
+    prg->setWindowTitle(QString("fitting %1 samples to %2 zernike terms").arg(m_rhoTheta.n_cols).arg(getNumberOfTerms()));
     prg->setMaximum( m_rhoTheta.n_cols);
     prg->setValue(0);
     prg->show();
@@ -1473,7 +1473,7 @@ std::vector<double>  zernikeProcess::ZernFitWavefront(wavefront &wf){
     wf.InputZerns = std::vector<double>(ztermCnt,0);
     for (int z = 0;  z < X.rows; ++z){
        if (z < wf.InputZerns.size()){
-            //qDebug() << z << X(z) << wf.InputZerns[z] << (QString().sprintf("% 6.4lf",X(z) - wf.InputZerns[z])).toDouble();
+            //qDebug() << z << X(z) << wf.InputZerns[z] << (QString("%1").arg(X(z) - wf.InputZerns[z], 6, 'f', 4)).toDouble();
         }
        else {
            //qDebug() << z << X(z);

--- a/zernikeprocess.cpp
+++ b/zernikeprocess.cpp
@@ -1322,7 +1322,7 @@ void dumpArma(arma::mat mm, QString title = "", QVector<QString> colHeading = QV
         if (!RowLable.empty()){
 
             if (row < RowLable.size()){
-                log.append(QString("<b>%1</b>").arg(RowLable[row].toStdString().c_str()));
+                log.append(QString("<b>%1</b>").arg(RowLable[row]));
             }
 
         }

--- a/zernikes.cpp
+++ b/zernikes.cpp
@@ -26,14 +26,14 @@ void dump_matrix (double *a, int nrows, int ncols,const char *desc)
 {
     int i, j;
     qDebug() << "###############";
-    qDebug() << QString().sprintf("%s", desc);
+    qDebug() << QString("%1").arg(desc);
     qDebug() << "###############";
-    qDebug() << QString().sprintf("%d, %d\n", nrows, ncols);
+    qDebug() << QString("%1, %2\n").arg(nrows).arg(ncols);
     for (i=0; i < nrows; i++)
     {
         for (j=0; j < ncols; j++)
         {
-            qDebug() << QString().sprintf("%f ", a[I(i, j, ncols)]);
+            qDebug() << QString("%1 ").arg(a[I(i, j, ncols)], 0, 'f');
         }
     }
 }
@@ -73,7 +73,7 @@ void zern_spec::dump(void)
     qDebug() <<  "       n   m   s";
     qDebug() <<  "      ----------";
     for (i=0; i < m_nterms; i++) {
-        qDebug() <<  QString().sprintf("%3d: %3d %3d %3d", i, m_n[i], m_m[i], m_s[i]);
+        qDebug() <<  QString("%1: %2 %3 %4").arg(i, 3).arg(m_n[i], 3).arg(m_m[i], 3).arg(m_s[i], 3);
     }
 }
 

--- a/zernikes.cpp
+++ b/zernikes.cpp
@@ -26,7 +26,7 @@ void dump_matrix (double *a, int nrows, int ncols,const char *desc)
 {
     int i, j;
     qDebug() << "###############";
-    qDebug() << QString("%1").arg(desc);
+    qDebug() << QString(desc);
     qDebug() << "###############";
     qDebug() << QString("%1, %2\n").arg(nrows).arg(ncols);
     for (i=0; i < nrows; i++)

--- a/zernikesmoothingdlg.cpp
+++ b/zernikesmoothingdlg.cpp
@@ -21,7 +21,7 @@ ZernikeSmoothingDlg::ZernikeSmoothingDlg(wavefront &wf, QWidget *parent) :
     QSettings set;
     m_maxOrder = set.value("Zern maxOrder", 12).toInt();
     ui->maxOrder->setValue(m_maxOrder);
-    ui->termCnt->setText(QString().sprintf("%d Terms",m_noOfTerms));
+    ui->termCnt->setText(QString("%1 Terms").arg(m_noOfTerms));
     connect(&m_timer, SIGNAL(timeout()), this, SLOT(intiZernTable()));
     tableModel->setValues(&m_wf.InputZerns);
     m_sm = SurfaceManager::get_instance();
@@ -57,7 +57,7 @@ void ZernikeSmoothingDlg::on_maxOrder_valueChanged(int arg1)
 
     m_zp->setMaxOrder(arg1);
     m_noOfTerms = m_zp->getNumberOfTerms();
-    ui->termCnt->setText(QString().sprintf("%d Terms",m_noOfTerms));
+    ui->termCnt->setText(QString("%1 Terms").arg(m_noOfTerms));
     theZerns.resize(m_noOfTerms);
     //tableModel->resizeRows(m_noOfTerms);
 
@@ -102,13 +102,13 @@ void ZernikeSmoothingDlg::on_createWaveFront_clicked()
 
     QStringList l = m_wf.name.split("/");
     l.back().replace(".wft","");
-    l.back().append(QString().sprintf("_sm%d",m_noOfTerms));
+    l.back().append(QString("_sm%1").arg(m_noOfTerms));
     m_sm->createSurfaceFromPhaseMap(result, m_wf.m_outside,
                                                 CircleOutline(QPointF(0,0),0),l.back());
 
     if (ui->showResidual->isChecked()){
         m_sm->subtract(&m_wf, m_sm->m_wavefronts.back(), false);
-        m_sm->m_wavefronts.back()->name = QString().sprintf("Residual_%d",m_noOfTerms);
+        m_sm->m_wavefronts.back()->name = QString("Residual_%1").arg(m_noOfTerms);
         m_sm->m_surfaceTools->nameChanged(m_sm->m_currentNdx,  m_sm->m_wavefronts.back()->name);
         m_sm->m_surfaceTools->currentNdxChanged(m_sm->m_currentNdx);
         m_sm->previous();


### PR DESCRIPTION
removed `QString().sprintf()` in favor of [.arg()](https://doc.qt.io/qt-5/qstring.html#arg)

This fixes about 204 occurrences of `[-Wdeprecated-declarations]`.

Also @githubdoe, what is the reason behind using  `sprintf("blabla %s", var.toStdString().c_str())` ? i feel like this is some unnecessary back and forth but I might miss some corner cases