### PR TITLE
Fixes some issues with regions that were causing DFTF to crash

### DIFF
--- a/dftarea.cpp
+++ b/dftarea.cpp
@@ -311,6 +311,17 @@ cv::Mat DFTArea::grayComplexMatfromImage(QImage &img){
         for (unsigned int i = 0; i < igramArea->m_polygons[n].size(); ++i){
             int x = round((igramArea->m_polygons[n][i].x - left) * scaleFactor);
             int y = round((igramArea->m_polygons[n][i].y - top) * scaleFactor);
+
+            // make sure x and y values of regions are inside our matrix
+            if (x < 0)
+                x=0;
+            if (x >= roi.cols)
+                x=roi.cols-1;
+            if (y < 0)
+                y=0;
+            if (y >= roi.rows)
+                y = roi.rows-1;
+
             m_poly.back().push_back(cv::Point(x,y));
         }
     }

--- a/igramarea.cpp
+++ b/igramarea.cpp
@@ -1962,8 +1962,8 @@ void IgramArea::saveRegions(){
     for (int i = 0; i < m_polygons.size(); ++i){
         regions << "Poly";
         for(int j = 0; j < m_polygons[i].size(); ++j){
-            regions << " " << QString().number(m_polygons[i][j].x) << ","<<
-                       QString().number(m_polygons[i][j].y);
+            regions << " " << QString().number(m_polygons[i][j].x+cropTotalDx) << ","<<
+                       QString().number(m_polygons[i][j].y+cropTotalDy);
         }
         regions << "\n";
     }
@@ -2030,6 +2030,7 @@ void IgramArea::crop() {
     x = igramGray.width()/2;
     y = igramGray.height()/2;
 
+
     for (int i = 0; i < m_polygons.size(); ++i){
         for(int j = 0; j < m_polygons[i].size(); ++j){
             m_polygons[i][j].x -=crop_dx;
@@ -2037,7 +2038,6 @@ void IgramArea::crop() {
         }
 
     }
-    saveRegions();
 
     m_outside.translate(QPointF(-crop_dx,-crop_dy));
     cx = m_outside.m_center.x() + crop_dx;
@@ -2262,6 +2262,7 @@ void IgramArea::writeOutlines(QString fileName){
             file << std::endl;
         }
     }
+    saveRegions(); // save regions to registry also
     if (m_edgeMaskWidth != 0){
         mirrorDlg &md = *mirrorDlg::get_Instance();
         file << "\nEdge Mask width" << std::endl << md.aperatureReduction << std::endl;

--- a/zernikeprocess.cpp
+++ b/zernikeprocess.cpp
@@ -848,7 +848,7 @@ void zernikeProcess::fillVoid(wavefront &wf){
                     if (x < 0 || y < 0 || x >= wf.data.cols || y >= wf.data.rows){
                         continue;
                     }
-                    if (wf.mask.at<bool>(y,x) == 0.){
+                    if (wf.mask.at<uchar>(y,x) == 0.){
                         ux = (double)(x - midx)/rad;
                         uy = (double)(y - midy)/rad;
                         rho = sqrt(ux * ux + uy * uy);

--- a/zernikeprocess.cpp
+++ b/zernikeprocess.cpp
@@ -848,7 +848,7 @@ void zernikeProcess::fillVoid(wavefront &wf){
                     if (x < 0 || y < 0 || x >= wf.data.cols || y >= wf.data.rows){
                         continue;
                     }
-                    if (wf.mask.at<uchar>(y,x) == 0.){
+                    if (wf.mask.at<uint8_t>(y,x) == 0){
                         ux = (double)(x - midx)/rad;
                         uy = (double)(y - midy)/rad;
                         rho = sqrt(ux * ux + uy * uy);


### PR DESCRIPTION
Fixes #36 

regions were scaled wrong when saved to registry (config memory - different from OLN files) such that they would typically go way off the left edge of the igram and not be visible to users and cause crashes.

Also fixed a bug where regions would be changed to their encompassing square.  But only in debug mode so didn't affect users.

Also changed it so regions are saved to registry (config) when you hit "done" and not when you hit "crop".  This way if the user makes a mistake with a region or other outline they can just reload the igram.