### PR TITLE
fix some compilation warnings [-Wunused

### DIFF
--- a/astigstatsdlg.cpp
+++ b/astigstatsdlg.cpp
@@ -703,7 +703,6 @@ void astigStatsDlg::usePolar(bool flag){
 
 void astigStatsDlg::on_distribution_clicked()
 {
-    bool first = true;
     if (distributionWindow == 0){
         distributionWindow = new QWidget();
         toolLayout = new QHBoxLayout;
@@ -735,9 +734,7 @@ void astigStatsDlg::on_distribution_clicked()
         layout->addWidget(editor);
     }
     else {
-        first = false;
         editor->clear();
-
     }
 
     if (PDFMode){

--- a/averagewavefrontfilesdlg.cpp
+++ b/averagewavefrontfilesdlg.cpp
@@ -43,7 +43,6 @@ void averageWaveFrontFilesDlg::on_process_clicked()
     bool first = true;
     abort = false;
     QStringList rejects;
-    bool configChanged = false;
     int count = ui->fileList->count();
     if (count == 0)
         return;

--- a/averagewavefrontfilesdlg.cpp
+++ b/averagewavefrontfilesdlg.cpp
@@ -61,7 +61,7 @@ void averageWaveFrontFilesDlg::on_process_clicked()
         QString name = item->text();
         ui->fileList->setCurrentRow(i);
         qApp->processEvents();
-        wavefront *wf = sm->readWaveFront(name,configChanged);
+        wavefront *wf = sm->readWaveFront(name);
         if (useFilter){
             sm->makeMask(wf);
             sm->generateSurfacefromWavefront(wf);

--- a/contourplot.cpp
+++ b/contourplot.cpp
@@ -82,8 +82,6 @@ public:
         lasty = pos.y();
         QColor bg( Qt::white );
         bg.setAlpha( 200 );
-        int x = thePlot->invTransform(QwtPlot::xBottom, pos.x());
-        int y = thePlot->invTransform(QwtPlot::yLeft, pos.y());
         double v = thePlot->d_spectrogram->data()->value(pos.x(),pos.y());
         int half = thePlot->m_wf->data.rows/2.;
         double delx = pos.x() - half;

--- a/dftarea.cpp
+++ b/dftarea.cpp
@@ -468,7 +468,6 @@ void DFTArea::doDFT(){
     magIImage = showMag(complexI,false,"", true, m_gamma);
 
 
-    double h = magIImage.height();
     QRect rec = QApplication::desktop()->screenGeometry();
 
 
@@ -614,7 +613,7 @@ cv::Mat DFTArea::vortex(QImage &img, double low)
 
     try
     {
-    int startMem = showmem("start Vortex");
+    showmem("start Vortex");
     cv::Mat image = grayComplexMatfromImage(img);
 
     // convert from 32 to 64 bit double values
@@ -1272,7 +1271,6 @@ cv::Mat atan2Mat(cv::Mat y, cv::Mat x){
     double* xptr = x.ptr<double>(0);
     double* yptr = y.ptr<double>(0);
     int last = x.total();
-    int cnt = 0;
     for (int i = 0; i < last; ++i ){
         resptr[i] = atan2(yptr[i],xptr[i]);
         //if (++cnt < 20)
@@ -1291,7 +1289,6 @@ arma::mat zpmCxx(double rho, double theta, int maxorder) {
 
   int order, nm, nm1mm1, nm1mp1, nm2m;
   int ncol = (mmax+1)*(mmax+1);
-  double a0;
   double cosmtheta[mmax], sinmtheta[mmax];
   arma::mat  zm(imax, ncol);
 
@@ -1444,7 +1441,6 @@ qDebug() << "dlg" << dlg.m_x << dlg.m_rad;
         int left = dlg.m_x - dlg.m_rad;
         int right = dlg.m_x + dlg.m_rad;
         int top = dlg.m_y - dlg.m_rad;
-        int bottom = dlg.m_y + dlg.m_rad;
         int width = dlg.m_rad * 2;
         int height = width;
         if (left < 0)

--- a/dftarea.cpp
+++ b/dftarea.cpp
@@ -468,10 +468,6 @@ void DFTArea::doDFT(){
     magIImage = showMag(complexI,false,"", true, m_gamma);
 
 
-    QRect rec = QApplication::desktop()->screenGeometry();
-
-
-
     magIImage = magIImage.scaled(magIImage.width() , magIImage.height() );
     setMinimumSize(magIImage.size());
 

--- a/foucaultview.cpp
+++ b/foucaultview.cpp
@@ -120,7 +120,6 @@ QVector<QPoint> scaleProfile(QPolygonF points, int width,
     }
     double xdel = right - left;
     double xscale = width/xdel;
-    double ydel = max - min;
     double yscale =  (width/2);
     QVector<QPoint> results;
     double cosangle = cos(angle);
@@ -164,9 +163,7 @@ void foucaultView::on_makePb_clicked()
     double gamma =     ui->gammaSb->value();
     mirrorDlg *md = mirrorDlg::get_Instance();
     double Radius = md->diameter/2.;
-    double inputWavelength = md->lambda;
     double r2 = Radius * Radius;
-    double fl = md->roc / 2.;
     double Fnumber =  .5 * md->roc/md->diameter;	//ROC is twice FL
     double unitMultiplyer = 1.;
     if (!ui->useMM->isChecked()){
@@ -484,7 +481,6 @@ void foucaultView::on_useMM_clicked(bool checked)
     ui->slitWidthSb->setSuffix(suffix);
     ui->lpiSb->setValue(ui->lpiSb->value() / mul);
     ui->gridGroupBox->setTitle((checked) ? "Ronchi LPmm ": "Ronchi LPI ");
-    double xx = ui->rocStepSize->value();
  //qDebug() << ui->rocStepSize->value() << mul << xx;
     ui->rocStepSize->setValue( mul * ui->rocStepSize->value());
     ui->scanEndOffset->setValue (mul * ui->scanEndOffset->value());
@@ -508,7 +504,6 @@ void foucaultView::on_scanPb_clicked()
     inscan = true;
     ui->scanPb->setText("Abort");
     qApp->processEvents();
-    double steps = ui->scanSteps->value();
     double start = ui->scanStart->value();
     double end = ui->scanEndOffset->value();
     double step = ui->scanSteps->value();

--- a/igramarea.cpp
+++ b/igramarea.cpp
@@ -453,7 +453,6 @@ cv::Point2d IgramArea::findBestOutsideOutline(cv::Mat gray, int start, int end,i
     MainWindow::me->progBar->setRange(0, cnt);
     cnt = 0;
     int goodCnt = 0;
-    double firstResp;
     double rmean;
     double rmeanpeak = 0;
     if (showDebug){
@@ -492,7 +491,6 @@ cv::Point2d IgramArea::findBestOutsideOutline(cv::Mat gray, int start, int end,i
         points << QPointF(rad0/searchOutlineScale, resp);
         double del;
         if (goodCnt == 0){
-            firstResp = resp;
             rmean = resp;
             oldDel = rmean;
             goodCnt = 1;
@@ -1213,14 +1211,12 @@ void IgramArea::increaseRegion(int n, double scale){
     yavg /= m_polygons[n].size();
     // find the closest point to the center
     double shortest = 99999;
-    int shortestndx;
     for (unsigned int i = 0; i < m_polygons[n].size(); ++i){
         int delx = m_polygons[n][i].x - xavg;
         int dely = m_polygons[n][i].y - yavg;
         double del = sqrt(delx * delx + dely * dely);
         if (del < shortest){
             shortest = del;
-            shortestndx = i;
         }
     }
 
@@ -1915,10 +1911,6 @@ void IgramArea::paintEvent(QPaintEvent *event)
 
         //bottom *************************************************************
         topy = (circle.m_center.ry() + circle.m_radius * e - viewW/2);
-        int shifty = 0;
-        if (topy > m_withOutlines.height()){
-            shifty = topy - m_withOutlines.height();
-        }
         roi = m_withOutlines.copy(topx,topy, viewW * 2, viewW);
         smallPainter.drawImage(viewW,  viewW, roi);
 
@@ -1926,11 +1918,6 @@ void IgramArea::paintEvent(QPaintEvent *event)
         topx = circle.m_center.rx() - circle.m_radius - viewW/2;
         topy = circle.m_center.ry() - viewW;
         roi = m_withOutlines.copy(topx,topy,viewW,viewW * 2);
-        int shiftl = 0;
-        if (topx < 0){
-            topx *= 1;
-            shiftl = topx;
-        }
         smallPainter.drawImage(0,0,roi);
 
 
@@ -1940,7 +1927,6 @@ void IgramArea::paintEvent(QPaintEvent *event)
 
         if (topx > m_withOutlines.width()){
             topx = topx -  m_withOutlines.width();
-            shiftl = topx;
         }
         roi = m_withOutlines.copy(topx,topy, viewW , viewW * 2);
 

--- a/igramarea.cpp
+++ b/igramarea.cpp
@@ -456,7 +456,6 @@ cv::Point2d IgramArea::findBestOutsideOutline(cv::Mat gray, int start, int end,i
     double firstResp;
     double rmean;
     double rmeanpeak = 0;
-    double avg;
     if (showDebug){
         cv::namedWindow("outline debug",cv::WINDOW_NORMAL);
         cv::moveWindow("outline debug", 10,10);
@@ -1873,7 +1872,6 @@ void IgramArea::paintEvent(QPaintEvent *event)
     QPainter painterThis(this);
     int pw = parentWidget()->width();
     int dw = pw/2;
-    int dh = parentWidget()->height();
 
     QRect dirtyRect = event->rect();
     if ((zoomIndex > 1 && m_zoomMode == EDGEZOOM) && (
@@ -1882,7 +1880,6 @@ void IgramArea::paintEvent(QPaintEvent *event)
             )){
         painterThis.fillRect(this->rect(), Qt::gray);
         int viewW = 3 * m_zoomBoxWidth / zoomIndex;
-        double scale = zoomIndex;
 
         QImage small(viewW * 4, viewW *2, igramColor.format());
         small.fill(Qt::gray);

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -1078,7 +1078,6 @@ void MainWindow::batchProcess(QStringList fileList){
     int last = fileList.size()-1;
 
     int ndx = 0;
-    VideoWriter *vw;
     int cnt = 0;
     int width, height;
     QString videoFileName;

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -63,20 +63,20 @@ MainWindow::MainWindow(QWidget *parent) :
     ui->setupUi(this);
 
 
-    const QString toolButtonStyle("QToolButton {"
-                                    "border-style: outset;"
-                                    "border-width: 3px;"
-                                    "border-radius:7px;"
-                                    "border-color: darkgray;"
-                                    "font: bold 12px;"
-                                    "min-width: 10em;"
-                                    "padding: 6px;}"
-                                "QToolButton:hover {background-color: lightblue;"
-                                        " }");
-    QWidget *rw = ui->toolBar->widgetForAction(ui->actionRead_WaveFront);
+    //const QString toolButtonStyle("QToolButton {"
+    //                                "border-style: outset;"
+    //                                "border-width: 3px;"
+    //                                "border-radius:7px;"
+    //                                "border-color: darkgray;"
+    //                                "font: bold 12px;"
+    //                                "min-width: 10em;"
+    //                                "padding: 6px;}"
+    //                            "QToolButton:hover {background-color: lightblue;"
+    //                                    " }");
+    //QWidget *rw = ui->toolBar->widgetForAction(ui->actionRead_WaveFront);
     //igramArea = new IgramArea(ui->tabWidget->widget(0));
 
-    rw = ui->toolBar->widgetForAction(ui->actionSubtract_wave_front);
+    //rw = ui->toolBar->widgetForAction(ui->actionSubtract_wave_front);
     //rw->setStyleSheet(toolButtonStyle);
     me = this;
     this->setAttribute(Qt::WA_DeleteOnClose);
@@ -1646,7 +1646,7 @@ void MainWindow::on_actionCreate_Movie_of_wavefronts_triggered()
 
 //                pd.setLabelText(name);
 //                QApplication::processEvents();
-//                wavefront *wf = m_surfaceManager->readWaveFront(name,false);
+//                wavefront *wf = m_surfaceManager->readWaveFront(name);
 
 //                m_surfaceManager->makeMask(wf);
 //                m_surfaceManager->generateSurfacefromWavefront(wf);

--- a/outlinedialog.cpp
+++ b/outlinedialog.cpp
@@ -35,7 +35,6 @@ outlineDialog::outlineDialog(double x, double y, double rad, QWidget *parent) :
 
     ui->display->setBackgroundRole(QPalette::Dark);
     ui->display->setAutoFillBackground(true);
-    QRect rec = QApplication::desktop()->screenGeometry();
     ui->showEdgePixelsCB->blockSignals(true);
     ui->showEdgePixelsCB->setChecked(false);
     ui->showEdgePixelsCB->blockSignals(false);
@@ -384,22 +383,14 @@ void outlineDialog::hideSearchcontrole(bool hide){
 }
 void outlineDialog::mousePressEvent(QMouseEvent *event)
 {
-
-
     if (event->button() == Qt::LeftButton) {
         QPointF Raw = event->pos();
-
-        QPointF pos = Raw;
 
         setCursor(Qt::OpenHandCursor);
         dragMode = true;
             //cntrlPressed = event->modifiers() & Qt::ControlModifier;
         lastPoint = Raw;
-        return;
-
     }
-
-
 }
 
 void outlineDialog::mouseMoveEvent(QMouseEvent *event)

--- a/outlinedialog.cpp
+++ b/outlinedialog.cpp
@@ -36,8 +36,6 @@ outlineDialog::outlineDialog(double x, double y, double rad, QWidget *parent) :
     ui->display->setBackgroundRole(QPalette::Dark);
     ui->display->setAutoFillBackground(true);
     QRect rec = QApplication::desktop()->screenGeometry();
-    int height = rec.height();
-    int width = rec.width();
     ui->showEdgePixelsCB->blockSignals(true);
     ui->showEdgePixelsCB->setChecked(false);
     ui->showEdgePixelsCB->blockSignals(false);

--- a/profileplot.cpp
+++ b/profileplot.cpp
@@ -659,7 +659,6 @@ void ProfilePlot::contourPointSelected(const QPointF &pos){
     double dely = pos.y() - m_wf->data.cols/2;
 
     double angle = atan2(delx,dely);  // swaped x and y to rotate by 90 deg.
-    double angle2 = angle;
     const double twopi = M_PI * 2.;
     // force 0 to 360
     if (angle < 0)

--- a/rotationdlg.cpp
+++ b/rotationdlg.cpp
@@ -43,7 +43,6 @@ RotationDlg::~RotationDlg()
 void RotationDlg::on_buttonBox_accepted()
 {
     int sign = (ui->CCWCB->isChecked()) ?  -1:1;
-    int interp = ui->interp->currentData().toInt();
     QSettings set;
     set.setValue("rotationAngle" ,ui->angleSB->value());
     set.setValue("rotationSign", sign);

--- a/simulationsview.cpp
+++ b/simulationsview.cpp
@@ -340,12 +340,11 @@ cv::Mat SimulationsView::computeStarTest(cv::Mat surface, int pupil_size, double
     // new padSize is fft_size/pad;
 
 
-        int padSize =  pupil_size/pad;
-        double dftRescale = padSize/(double)nx;
-        dX = (m_wf->diameter/2.)/m_wf->m_outside.m_radius;
+    int padSize =  pupil_size/pad;
+    dX = (m_wf->diameter/2.)/m_wf->m_outside.m_radius;
 
-        cv::resize(tmp[0],tmp[0],cv::Size(padSize,padSize),cv::INTER_AREA);
-        cv::resize(tmp[1],tmp[1],cv::Size(padSize,padSize),cv::INTER_AREA);
+    cv::resize(tmp[0],tmp[0],cv::Size(padSize,padSize),cv::INTER_AREA);
+    cv::resize(tmp[1],tmp[1],cv::Size(padSize,padSize),cv::INTER_AREA);
 
 
     cv::Mat in[] = {cv::Mat::zeros(Size(pupil_size,pupil_size),CV_64FC1)

--- a/surfacegraph.cpp
+++ b/surfacegraph.cpp
@@ -224,7 +224,6 @@ void SurfaceGraph::fillSurfaceProxy() {
     cv::Mat data;
     m_wf->workData.copyTo(data);
     double min,max;
-    int id1,id2;
     min = m_wf->min;
     max = m_wf->max;
     double mean = m_wf->mean;
@@ -244,10 +243,8 @@ void SurfaceGraph::fillSurfaceProxy() {
 
 
     double mmperstep = (diam/2)/(m_wf->m_outside.m_radius);
-    float stepX = mmperstep;
 
     int steps = 1;
-    float stepZ = stepX;
     sampleCountZ = data.rows;
     sampleCountX = data.cols;
     QSurfaceDataArray *dataArray = new QSurfaceDataArray;

--- a/surfacegraph.cpp
+++ b/surfacegraph.cpp
@@ -223,9 +223,8 @@ void SurfaceGraph::fillSurfaceProxy() {
     double diam = m_wf->diameter;
     cv::Mat data;
     m_wf->workData.copyTo(data);
-    double min,max;
+    double min;
     min = m_wf->min;
-    max = m_wf->max;
     double mean = m_wf->mean;
     double std = m_wf->std;
 

--- a/surfacemanager.cpp
+++ b/surfacemanager.cpp
@@ -628,14 +628,12 @@ void SurfaceManager::makeMask(wavefront *wf, bool useInsideCircle){
             yavg /= wf->regions[n].size();
             // find the closest point to the center
             double shortest = 99999;
-            int shortestndx;
             for (int i = 0; i < wf->regions[n].size(); ++i){
                 int delx = wf->regions[n][i].x - xavg;
                 int dely = wf->regions[n][i].y - yavg;
                 double del = sqrt(delx * delx + dely * dely);
                 if (del < shortest){
                     shortest = del;
-                    shortestndx = i;
                 }
             }
             double scale = 1.1 * (shortest+2)/shortest;
@@ -1066,7 +1064,7 @@ void SurfaceManager::createSurfaceFromPhaseMap(cv::Mat phase, CircleOutline outs
     emit showTab(2);
 }
 
-wavefront * SurfaceManager::readWaveFront(QString fileName, bool mirrorParamsChanged){
+wavefront * SurfaceManager::readWaveFront(QString fileName){
     std::ifstream file(fileName.toStdString().c_str());
     if (!file) {
         QString b = "Can not read file " + fileName + " " +strerror(errno);
@@ -1169,9 +1167,6 @@ wavefront * SurfaceManager::readWaveFront(QString fileName, bool mirrorParamsCha
         if ( lambdResp == YES || messageResult == QMessageBox::Yes){
             md->newLambda(QString::number(lambda));
         }
-        else {
-            mirrorParamsChanged = true;
-        }
     }
 
     if (roundl(diam * 10) != roundl(md->diameter* 10))
@@ -1198,7 +1193,6 @@ wavefront * SurfaceManager::readWaveFront(QString fileName, bool mirrorParamsCha
         }
         else {
             diam = md->diameter;
-            mirrorParamsChanged = true;
         }
 
     }
@@ -1273,7 +1267,7 @@ bool SurfaceManager::loadWavefront(const QString &fileName){
         deleteCurrent();
     }
 
-        wf = readWaveFront(fileName, mirrorParamsChanged);
+        wf = readWaveFront(fileName);
         m_wavefronts << wf;
 
         wf->name = fileName;
@@ -2704,7 +2698,6 @@ void SurfaceManager::report(){
     int finalWidth =  QGuiApplication::screens()[0]->geometry().width()/2.5;
 
     printer.setFullPage( true );
-    QMargins marg = printer.pageLayout().marginsPixels(printer.resolution());
 
     printer.setOutputFileName( dlg.fileName );
     int width = printer.width();
@@ -2850,7 +2843,6 @@ void SurfaceManager::report(){
         oglw.show();    // show on stack to get metrics.
         QFontMetrics fm =    oglw.fontMetrics();
         QRect tw = fm.boundingRect("Waves 550 nm Waves");
-        QRect lg = oglw.getLegend()->geometry();
         QRect sg = oglw.getModel()->geometry();
 
         int surfw = sg.width() + tw.width();

--- a/surfacemanager.cpp
+++ b/surfacemanager.cpp
@@ -1660,7 +1660,7 @@ void SurfaceManager::rotateThese(double angle, QList<int> list){
         m_currentNdx = m_wavefronts.size()-1;
         m_surfaceTools->select(m_currentNdx);
         //wf->mask = cv::Mat::zeros(wf->data.size(), CV_8UC1);
-        uchar ones = 0xff;
+        //uchar ones = 0xff;
         //fillCircle(wf->mask, wf->m_outside.m_center.x(), wf->m_outside.m_center.y(),
                    //wf->m_outside.m_radius, &ones);
 
@@ -2864,7 +2864,6 @@ void SurfaceManager::report(){
         imagesHtml.append("<p ><br>&nbsp;</p>");
         imagesHtml.append("<img src='" + surfPath + "'>");
     }
-    int lastH = 0;
     // star test
     if (dlg.ui->showStarTest->isChecked()){
 
@@ -3173,7 +3172,6 @@ void SurfaceManager::tiltAnalysis(){
    QwtPlotCurve *yTilt = new QwtPlotCurve("y");
    xTilt->setStyle(QwtPlotCurve::Dots);
    yTilt->setStyle(QwtPlotCurve::Dots);
-   QwtPlotCurve *xTLine = new QwtPlotCurve("X fit");
    xTilt->setPen(Qt::red,4);
    yTilt->setPen(Qt::blue,4);
    xTilt->setSamples(xvals.toVector());

--- a/surfacemanager.h
+++ b/surfacemanager.h
@@ -77,7 +77,7 @@ public:
     void averageWavefrontFiles(QStringList files);
     void downSizeWf(wavefront *wf);
     void process(int wavefront_index, SurfaceManager *sm);
-    wavefront *readWaveFront(QString fileName, bool mirrorParamsChanged);
+    wavefront *readWaveFront(QString fileName);
     inline wavefront *getCurrent(){
         if (m_wavefronts.size() == 0)
             return 0;

--- a/zernikeprocess.cpp
+++ b/zernikeprocess.cpp
@@ -1118,7 +1118,7 @@ void ZernikeSmooth(cv::Mat wf, cv::Mat mask)
 
 
 arma::mat zernikeProcess::rhotheta( int width, double radius, double cx, double cy,
-                                   double insideRad, const wavefront *wf){
+                                   const wavefront *wf){
     bool useMask = false;
     if (wf != 0){
         useMask = true;
@@ -1126,7 +1126,6 @@ arma::mat zernikeProcess::rhotheta( int width, double radius, double cx, double 
         width = wf->data.rows;
         cx = wf->m_outside.m_center.x();
         cy = wf->m_outside.m_center.y();
-        insideRad = wf->m_inside.m_radius;
     }
     int rows = width;
 
@@ -1170,7 +1169,6 @@ arma::mat zernikeProcess::zpmC(arma::rowvec rho, arma::rowvec theta, int maxorde
     unsigned int i, imax = rho.size();
     int order, nm, nm1mm1, nm1mp1, nm2m;
     int ncol = (mmax+1)*(mmax+1);
-    double a0;
     double cosmtheta[mmax], sinmtheta[mmax];
     arma::mat zm(imax, ncol);
 
@@ -1219,7 +1217,6 @@ arma::mat zernikeProcess::zpmC(arma::rowvec rho, arma::rowvec theta, int maxorde
       for (order=2; order <= maxorder; order+=2) {
           for(m=order/2; n0 < ncol && m>0; m--) {
               n=order-m;
-              a0 = m_norms[n0] = sqrt(2.*(n+1));
               if (n0 < m_norms.size()-2){
                   m_norms[n0+1] = m_norms[n0];
                   zm(i, n0+1) = sinmtheta[m-1]*zm(i, n0);
@@ -1358,7 +1355,7 @@ void zernikeProcess::initGrid(int width, double radius, double cx, double cy, in
         m_gridRowSize = width;
         m_radius = radius;
         m_obsPercent = obsPercent;
-        m_rhoTheta = rhotheta(width, radius, cx, cy, m_obsPercent);
+        m_rhoTheta = rhotheta(width, radius, cx, cy);
 
         if (obsPercent <= 0.) {
             m_zerns = zpmC(m_rhoTheta.row(0), m_rhoTheta.row(1), maxOrder);

--- a/zernikeprocess.cpp
+++ b/zernikeprocess.cpp
@@ -873,8 +873,12 @@ int zernikeProcess::getNumberOfTerms(){
 }
 void spectral_color(double &R,double &G,double &B,double wavelength)
 // RGB <0,1> <- lambda l <400,700> [nm]
-{ double t; R=0.0; G=0.0;
-    B=0.0; double gamma = .8;double attenuation = 1;
+{ 
+    R=0.0; 
+    G=0.0; 
+    B=0.0; 
+    double gamma = .8;
+    double attenuation = 1;
 
     if (wavelength >= 380 && wavelength <= 440){
         attenuation = 0.3 + 0.7 * (wavelength - 380) / (440 - 380);
@@ -959,20 +963,16 @@ cv::Mat zernikeProcess::makeSurfaceFromZerns(int border, bool doColor){
     simIgramDlg &dlg = *simIgramDlg::get_instance();
     double obs = .01 * dlg.getObs();
     int wx = dlg.size + 2 *  border;
-    int wy = wx;
     double rad = (double)(wx-1)/2.;
-    double xcen = rad,ycen = rad;
     rad -= border;
     cv::Mat result = cv::Mat::ones(wx,wx, (doColor)? CV_8UC4: numType);
 
 
 
     initGrid(wx, rad, (wx-1)/2, (wx-1)/2, m_maxOrder, 0);
-    double rho;
     double spacing = 1.;
     mirrorDlg *md = mirrorDlg::get_Instance();
     qDebug() << "fringe spacing" << md->fringeSpacing;
-    zernikePolar &zpolar = *zernikePolar::get_Instance();
     double r,g,b;
     spectral_color(r,g,b, md->lambda);
     if (doColor) {
@@ -990,7 +990,6 @@ cv::Mat zernikeProcess::makeSurfaceFromZerns(int border, bool doColor){
 
         double rho = m_rhoTheta.row(0)(i);
         double theta = m_rhoTheta.row(1)(i);
-        double edge = .95;
         double S1 =
                 dlg.star * cos(dlg.m_star_arms  *  theta) +
                 dlg.ring * cos (dlg.m_ring_count * 2 * M_PI * rho);
@@ -1415,21 +1414,15 @@ std::vector<double>  zernikeProcess::ZernFitWavefront(wavefront &wf){
     'calculate LSF matrix elements
     */
 
-    Settings2 &settings = *Settings2::getInstance();
-
     cv::Mat_<double> A;//(count,Z_TERMS);
     cv::Mat_<double> B;//(count,1);
     cv::Mat_<double> X(ztermCnt,1);
-    int count = 0;
 
     A = cv::Mat_<double>::zeros(ztermCnt,ztermCnt);
     B = cv::Mat_<double>::zeros(ztermCnt,1);
 
     //calculate LSF right hand side
 
-    double delta = 1./(wf.m_outside.m_radius);
-
-    int sampleCnt = 0;
     QProgressDialog *prg = new QProgressDialog;
     prg->setWindowTitle(QString("fitting %1 samples to %2 zernike terms").arg(m_rhoTheta.n_cols).arg(getNumberOfTerms()));
     prg->setMaximum( m_rhoTheta.n_cols);
@@ -1498,9 +1491,6 @@ void make3DPsf(cv::Mat surface){
     hLayout->addLayout(vLayout);
     plotWindow->setLayout(hLayout);
 
-
-    int nx = surface.size[0];
-    int start = nx/2 - nx/4;
     cv::Mat data = surface.clone();//(cv::Rect(start,start,nx/2,nx/2));
 
 
@@ -1576,7 +1566,6 @@ void make3DPsf(cv::Mat surface){
 #include "zernikesmoothingdlg.h"
 using namespace cv;
 void debugZernRoutines(wavefront &wf){
-    int rows = 2;
     int cols = 4;
     for (int i = 0; i < 10; ++i) {
         qDebug() << i << i/cols << i%cols;

--- a/zernikeprocess.h
+++ b/zernikeprocess.h
@@ -114,7 +114,7 @@ public:
     cv::Mat makeSurfaceFromZerns(int border, bool doColor);
 
     arma::mat rhotheta( int width, double radius, double cx, double cy,
-                                       double insideRad, const wavefront *wf = 0);
+                                       const wavefront *wf = 0);
 
     arma::mat zpmC(arma::rowvec rho, arma::rowvec theta, int maxorder);
     arma::mat zapmC(const arma::rowvec& rho, const arma::rowvec& theta, const int& maxorder=12);


### PR DESCRIPTION
### Before PR on my local build:
[-Wunused-local-typedefs] 32
[-Wunused-variable] 40
[-Wunused-but-set-variable] 25
[-W 333

### After PR on my local build:
[-Wunused-local-typedefs] 32 👎 
[-Wunused-variable] 0 👍 
[-Wunused-but-set-variable] 10 👎 
[-W 276 (meaning 2 other random warnings disapeared in the process)

- Remaining [-Wunused-local-typedefs] all come from armadillo. FYI this has not been fixed in latest version 12.6.0 but I opened an issue and next release will work fine https://gitlab.com/conradsnicta/armadillo-code/-/issues/239 will be corrected in #53 as soon as Armadillo publish a release (usually 1-2 month)
- Remaining use_alpha set but not used [-Wunused-but-set-variable] => I believe this is a compiler bug: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=96311 . Would probably be fixed if we upgrade compiler (for this we need to update QT).