### PR TITLE
Fixed all bugs related to rotating and averaging when there are regions or central obstruction

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -261,7 +261,7 @@ MainWindow::MainWindow(QWidget *parent) :
 }
 int showmem(QString t);
 void MainWindow::openWaveFrontonInit(QStringList args){
-    QProgressDialog pd("    Loading wavefronts in PRogress.", "Cancel", 0, 100);
+    QProgressDialog pd("    Loading wavefronts in progress.", "Cancel", 0, 100);
     pd.setRange(0, args.size());
     if (args.length()> 0)
         pd.show();

--- a/mirrordlg.h
+++ b/mirrordlg.h
@@ -41,7 +41,7 @@ public:
     double diameter;
     double roc;
     double FNumber;
-    double obs;
+    double obs; // obstruction
     double cc;
     bool doNull;
     double z8;

--- a/pixelstats.cpp
+++ b/pixelstats.cpp
@@ -331,8 +331,8 @@ cv::Mat slope(wavefront * wf){
     for (int y = 0; y < wf->data.rows; ++y){
         for (int x = 0; x < wf->data.cols; ++x){
             double avg = 0;
-            if (wf->workMask.at<bool>(y,x) && (x + pixelsPerInch) < wf->workData.cols   &&
-                    wf->workMask.at<bool>(y,x+pixelsPerInch)){
+            if (wf->workMask.at<uint8_t>(y,x) && (x + pixelsPerInch) < wf->workData.cols   &&
+                    wf->workMask.at<uint8_t>(y,x+pixelsPerInch)){
                 for (int i = 0; i < pixelsPerInch; ++i){
                         avg += wf->workData(y,x+i);
                 }
@@ -346,8 +346,8 @@ cv::Mat slope(wavefront * wf){
         for (int y = 0; y < wf->data.rows; ++y){
             double avg = 0;
 
-            if (wf->workMask.at<bool>(y,x) && (y + pixelsPerInch) < wf->workData.rows   &&
-                    wf->workMask.at<bool>(y + pixelsPerInch,x)){
+            if (wf->workMask.at<uint8_t>(y,x) && (y + pixelsPerInch) < wf->workData.rows   &&
+                    wf->workMask.at<uint8_t>(y + pixelsPerInch,x)){
                 for (int i = 0; i < pixelsPerInch; ++i){
                     avg += wf->workData(y+i,x);
                 }
@@ -359,7 +359,7 @@ cv::Mat slope(wavefront * wf){
     for(int y = 0; y < wf->data.rows-1; ++y){
 
          for (int x = 0; x < wf->data.cols-1; ++x){
-            if (wf->workMask.at<bool>(y,x) && x+dist < wf->data.cols && wf->workMask.at<bool>(y,x+1)){
+            if (wf->workMask.at<uint8_t>(y,x) && x+dist < wf->data.cols && wf->workMask.at<uint8_t>(y,x+1)){
                 double h  = avgX.at<double>(y,x ) - avgX.at<double>(y,x+dist);
                 if ( y == half){
 
@@ -371,7 +371,7 @@ cv::Mat slope(wavefront * wf){
             else{
                 gradx.at<double>(y,x) = 0.;
             }
-            if (wf->workMask.at<bool>(y,x) && y+dist < wf->data.rows && wf->workMask.at<bool>(y+1,x)){
+            if (wf->workMask.at<uint8_t>(y,x) && y+dist < wf->data.rows && wf->workMask.at<uint8_t>(y+1,x)){
                 double h = avgY.at<double>(y,x ) - avgY.at<double>(y+dist,x);
                 double slope = atan2(h, wavePerPixel) * radToArcSec;
                 grady.at<double>(y,x) = fabs(slope);
@@ -416,7 +416,7 @@ void pixelStats::updateSurface(){
         for (int x = 0; x < sur.cols; ++x){
             for (int y = 0; y < sur.rows; ++y){
                 double v = m_wf->workData.at<double>(y,x);
-                if (m_wf->workMask.at<bool>(y,x)){
+                if (m_wf->workMask.at<uint8_t>(y,x)){
                     if (v > ub){
                         sur.at<cv::Vec3b>(y,x) =cv::Vec3b(255,0,0);
                     }
@@ -440,7 +440,7 @@ void pixelStats::updateSurface(){
             for (int x = 0; x < sur.cols; ++x){
                 for (int y = 0; y < sur.rows; ++y){
                     double v = mag.at<double>(y,x);
-                    if (m_wf->workMask.at<bool>(y,x)){
+                    if (m_wf->workMask.at<uint8_t>(y,x)){
                         if (fabs(v) > slopeLimitArcSec){
                             int c = 255 -125 * (fabs(v)-slopeLimitArcSec)/vmax;
                             sur.at<cv::Vec3b>(y,x) =cv::Vec3b(c,c,0);

--- a/profileplot.cpp
+++ b/profileplot.cpp
@@ -360,7 +360,7 @@ QPolygonF ProfilePlot::createProfile(double units, wavefront *wf){
             continue;
         }
 
-        if (wf->workMask.at<bool>(dy,dx)){
+        if (wf->workMask.at<uint8_t>(dy,dx)){
                 double defocus = 0.;
 
                 if (m_defocus_mode){

--- a/wavefront.cpp
+++ b/wavefront.cpp
@@ -18,7 +18,7 @@
 #include "wavefront.h"
 
 wavefront::wavefront():
-    gaussian_diameter(0.),useSANull(true),dirtyZerns(true)
+    gaussian_diameter(0.),useSANull(true),dirtyZerns(true),regions_have_been_expanded(false)
 {
 }
 

--- a/wavefront.h
+++ b/wavefront.h
@@ -28,9 +28,9 @@ public:
     wavefront( wavefront &wf);
     cv::Mat_<double> data;
     cv::Mat_<double> nulledData;
-    cv::Mat_<bool> mask;
+    cv::Mat_<uint8_t> mask;
     cv::Mat_<double> workData;
-    cv::Mat_<bool> workMask;
+    cv::Mat_<uint8_t> workMask;
     std::vector<double> InputZerns;
     double gaussian_diameter;
     bool wasSmoothed;
@@ -49,6 +49,7 @@ public:
     double mean;
     bool dirtyZerns;
     QVector<std::vector<cv::Point> > regions;
+    bool regions_have_been_expanded;
 
 
 };


### PR DESCRIPTION
summary of edits:
- bilinear() had some typos where masked points outside mirror edge could be averaged in when rotating
- Made it so masked regions only grow once
- rotation uses only outer edge mask now as everything else should rotate
- fillvoid() always fills center region if it exists.  This eliminates tons of bugs if the center obstruction region changes sizes or position and then we average
- fixed bug when reading wavefronts where central obstruction moved due to rounding error: float to int then back to float

cleanup stuff:
Changed all mask.at<bool> to mask.at<uint8_t>  (some <uchar> were left as is) Fixed all warnings in surfacemanager.cpp
(unused includes, int --> unsigned int, tabbing warnings