### PR TITLE
never do `using namespace std`

### DIFF
--- a/astigstatsdlg.cpp
+++ b/astigstatsdlg.cpp
@@ -384,7 +384,7 @@ void astigStatsDlg::plot(){
     // find the limits
     double xmag = std::max(fabs(xmin), fabs(xmax)) * 1.25;
     double ymag = std::max(fabs(ymin), fabs(ymax))*1.25;
-    double maxmag = max(xmag,ymag);
+    double maxmag = std::max(xmag,ymag);
     ui->mPlot->setAxisScale(QwtPlot::xBottom, -maxmag, maxmag);
     ui->mPlot->setAxisScale(QwtPlot::yLeft,   -maxmag, maxmag);
     ui->mPlot->setAxisTitle(QwtPlot::xBottom,"wavefront X astig");
@@ -608,7 +608,7 @@ QwtPlot *astigStatsDlg::avgPlot(cv::Mat x, cv::Mat y, int width){
     runy->setPen(Qt::black,3);
     runy->attach(plot);
     plot->setAxisScale(QwtPlot::yLeft,
-                      min(xrs.min(), yrs.min()) - .01, max(xrs.max(), yrs.max()) + .1);
+                      std::min(xrs.min(), yrs.min()) - .01, std::max(xrs.max(), yrs.max()) + .1);
     if (m_usePolar){
         plot->enableAxis(QwtPlot::yRight);
         plot->setAxisScale(QwtPlot::yRight, yrs.min() - 7, yrs.max() + 3);

--- a/circlefit.cpp
+++ b/circlefit.cpp
@@ -29,9 +29,9 @@ Circle::Circle(double aa, double bb, double rr)
 
 void Circle::print(void)
 {
-    cout << endl;
-    cout << setprecision(10) << "center (" <<a <<","<< b <<")  radius "
-         << r << "  sigma " << s << "  gradient " << g << "  iter "<< i << "  inner " << j << endl;
+    std::cout << std::endl;
+    std::cout << std::setprecision(10) << "center (" <<a <<","<< b <<")  radius "
+         << r << "  sigma " << s << "  gradient " << g << "  iter "<< i << "  inner " << j << std::endl;
 }
 
 //****************** Sigma ************************************
@@ -279,7 +279,7 @@ Circle CircleFitByHyper (CircleData& data)
     {
         Dy = A1 + x*(A22 + 16.*x*x);
         xnew = x - y/Dy;
-        if ((xnew == x)||(!isfinite(xnew))) break;
+        if ((xnew == x)||(!std::isfinite(xnew))) break;
         ynew = A0 + xnew*(A1 + xnew*(A2 + Four*xnew*xnew));
         if (abs(ynew)>=abs(y))  break;
         x = xnew;  y = ynew;
@@ -503,7 +503,7 @@ Circle CircleFitByPratt (CircleData &data)
     {
         Dy = A1 + x*(A22 + 16.*x*x);
         xnew = x - y/Dy;
-        if ((xnew == x)||(!isfinite(xnew))) break;
+        if ((xnew == x)||(!std::isfinite(xnew))) break;
         ynew = A0 + xnew*(A1 + xnew*(A2 + Four*xnew*xnew));
         if (abs(ynew)>=abs(y))  break;
         x = xnew;  y = ynew;
@@ -631,7 +631,7 @@ Circle CircleFitByTaubin (CircleData& data)
     {
             Dy = A1 + x*(A22 + A33*x);
         xnew = x - y/Dy;
-        if ((xnew == x)||(!isfinite(xnew))) break;
+        if ((xnew == x)||(!std::isfinite(xnew))) break;
         ynew = A0 + xnew*(A1 + xnew*(A2 + xnew*A3));
         if (abs(ynew)>=abs(y))  break;
         x = xnew;  y = ynew;

--- a/circleutils.h
+++ b/circleutils.h
@@ -6,7 +6,6 @@
 #include <iomanip>
 #include <cstdlib>
 #include "circle.h"
-using namespace std;
 
 class CircleData
 {
@@ -42,9 +41,9 @@ typedef long long integers;
 const double One=1.0,Two=2.0,Three=3.0,Four=4.0,Five=5.0,Six=6.0,Ten=10.0;
 //const reals One=1.0L,Two=2.0L,Three=3.0L,Four=4.0L,Five=5.0L,Six=6.0L,Ten=10.0L;
 const double Pi=3.141592653589793238462643383L;
-const double REAL_MAX=numeric_limits<double>::max();
-const double REAL_MIN=numeric_limits<double>::min();
-const double REAL_EPSILON=numeric_limits<double>::epsilon();
+const double REAL_MAX=std::numeric_limits<double>::max();
+const double REAL_MIN=std::numeric_limits<double>::min();
+const double REAL_EPSILON=std::numeric_limits<double>::epsilon();
 
 //   next define some frequently used functions:
 

--- a/dftarea.cpp
+++ b/dftarea.cpp
@@ -265,8 +265,8 @@ cv::Mat DFTArea::grayComplexMatfromImage(QImage &img){
     double left = centerX - rad;
     double top = centerY - rad;
     std::vector<Mat > bgr_planes;
-    top = max(top,0.);
-    left = max(left,0.);
+    top = std::max(top,0.);
+    left = std::max(left,0.);
     int width = 2. * (rad);
     int height = width;
     width = min(width, img.width());

--- a/generatetargetdlg.cpp
+++ b/generatetargetdlg.cpp
@@ -10,7 +10,6 @@
 #include <QDebug>
 #include <QSettings>
 using namespace cv;
-using namespace std;
 
 generateTargetDlg::generateTargetDlg(QWidget *parent) :
     QDialog(parent),m_units(INCHES),

--- a/imagehisto.cpp
+++ b/imagehisto.cpp
@@ -20,9 +20,6 @@
 #include <iostream>
 
 using namespace cv;
-using namespace std;
-
-
 
 int _brightness = 100;
 int _contrast = 100;

--- a/mikespsirinterface.cpp
+++ b/mikespsirinterface.cpp
@@ -12,7 +12,6 @@
 #include "qmath.h"
 #include <QDebug>
 #include <QMap>
-using namespace std;
 // create two row vectors containing rho and theta values of the inclosed circular pupil
 // return them as two columns of a mat.
 

--- a/punwrap.cpp
+++ b/punwrap.cpp
@@ -21,7 +21,6 @@
 #include <algorithm>
 #include <queue>
 #include <cstring>
-using namespace std;
 int xsize,ysize;
 double* qmap = NULL;
 double* phase;
@@ -185,8 +184,8 @@ void dv_quality_map (double *pphase,int width, double *qmap, int nx, int ny)
     for (int y=0; y < ny; ++y) {
       int n = 0;
       // Load elements from window into ex and ey.
-      for (int i = max(x+start, 0); i < min(x+end, nx-1); ++i)
-            for (int j = max(y+start, 0); j < min(y+end, ny-1); ++j) {
+      for (int i = std::max(x+start, 0); i < std::min(x+end, nx-1); ++i)
+            for (int j = std::max(y+start, 0); j < std::min(y+end, ny-1); ++j) {
                 int ndx = j*nx + i;
                 if (0.0 != (dx[ndx]) && 0.0 != (dy[ndx])) {
                     ex[n] = dx[ndx];
@@ -236,8 +235,8 @@ void pc_quality_map (int nx, int ny, double *phase, int width, double *qmap)
 
       int n = 0;
       // Load elements from window into ex and ey.
-      for (int i = max(x+start, 0); i < min(x+end, nx-1); ++i)
-    for (int j = max(y+start, 0); j < min(y+end, ny-1); ++j) {
+      for (int i = std::max(x+start, 0); i < std::min(x+end, nx-1); ++i)
+    for (int j = std::max(y+start, 0); j < std::min(y+end, ny-1); ++j) {
       int ndx = j*nx + i;
       if (0.0 != (phase[ndx])) {
         ep[n] = phase[ndx];
@@ -282,7 +281,7 @@ public:
     }
 };
 
-priority_queue<qual,vector<qual>,comp_qual> To_Do;
+std::priority_queue<qual,std::vector<qual>,comp_qual> To_Do;
 /* input is normalized from 0 to 1 */
 
 #define GRAD(x) (((x) > 0.5) ? ((x)-1.0) : (((x) <= -0.5) ? ((x)+1.0) : (x)))

--- a/surfacemanager.cpp
+++ b/surfacemanager.cpp
@@ -1971,9 +1971,9 @@ textres SurfaceManager::Phase2(QList<rotationDef *> list, QList<wavefront *> inp
         double mirrorY = inputs[i]->InputZerns[5];
         xastig.at<double>(i,0) = mirrorX;
         mirrorXaverage += mirrorX;
-        maxXastig = max(maxXastig,mirrorX);
+        maxXastig = std::max(maxXastig,mirrorX);
         mirrorYAverage += mirrorY;
-        maxYastig = max(maxYastig, mirrorY);
+        maxYastig = std::max(maxYastig, mirrorY);
         yastig.at<double>(i,0) = mirrorY;
         qDebug() << "Mirror astigs " << mirrorX << mirrorY;
     }
@@ -2065,10 +2065,10 @@ qDebug() << "circle fit"<< avgRadius << fittedcircle1.r << fittedcircle2.r;
     for (int i = 0; i < list.size(); ++i){
         double xval = standxastig.at<double>(i,0);
         double yval = standyastig.at<double>(i,0);
-        maxX = max(maxX, xval);
-        minX = min(minX, xval);
-        maxY = max(maxY, yval);
-        minY = min(minY, yval);
+        maxX = std::max(maxX, xval);
+        minX = std::min(minX, xval);
+        maxY = std::max(maxY, yval);
+        minY = std::min(minY, yval);
 
         double mag = sqrt(pow(xval,2) + pow(yval,2));
 
@@ -2279,11 +2279,11 @@ qDebug() << "circle fit"<< avgRadius << fittedcircle1.r << fittedcircle2.r;
 
     }
 
-    double maxv = max(fabs(mirrorYastig) +  fabs(mirrorAstigRadius),fabs(mirrorXastig ) + fabs(mirrorAstigRadius))  * 1.2;
-    maxv = max(maxX, maxv);
-    maxv = max(fabs(minX), maxv);
-    maxv = max(maxv, maxY);
-    maxv = max(fabs(minY), maxv);
+    double maxv = std::max(fabs(mirrorYastig) +  fabs(mirrorAstigRadius),fabs(mirrorXastig ) + fabs(mirrorAstigRadius))  * 1.2;
+    maxv = std::max(maxX, maxv);
+    maxv = std::max(fabs(minX), maxv);
+    maxv = std::max(maxv, maxY);
+    maxv = std::max(fabs(minY), maxv);
     pl1->setAxisScale(QwtPlot::xBottom, -maxv, maxv);
     pl1->setAxisScale(QwtPlot::yLeft,   -maxv, maxv);
     QColor color(Qt::green);

--- a/zernikeprocess.cpp
+++ b/zernikeprocess.cpp
@@ -1182,10 +1182,10 @@ arma::mat zernikeProcess::rhotheta( int width, double radius, double cx, double 
     }
     int rows = width;
 
-    vector<double> rhov;
-    vector<double> thetav;
-     m_row.clear();
-     m_col.clear();
+    std::vector<double> rhov;
+    std::vector<double> thetav;
+    m_row.clear();
+    m_col.clear();
 
     for (int y = 0; y < rows; ++y){
         double uy = (y -cy)/radius;

--- a/zernikeprocess.h
+++ b/zernikeprocess.h
@@ -25,7 +25,6 @@
 #include "mainwindow.h"
 #include "armadillo"
 #include <stdlib.h>
-using namespace std;
 extern std::vector<bool> zernEnables;
 extern int Zw[];
 extern double BestSC;
@@ -34,12 +33,12 @@ void gauss_jordan(int n, double* Am, double* Bm);
 void ZernikeSmooth(Mat wf, Mat mask);
 
 typedef struct  {
-    vector<bool> enables;
-    vector<double> norms;
+    std::vector<bool> enables;
+    std::vector<double> norms;
     int maxOrder;
     int noOfTerms;
-    vector<int> rowIndex;
-    vector<int> colIndex;
+    std::vector<int> rowIndex;
+    std::vector<int> colIndex;
     arma::mat zernsArSample;
     arma::mat rhoTheta;
     int widthOfMatrix;
@@ -128,8 +127,8 @@ public:
     MainWindow *mw;
     arma::mat m_zerns;
     QVector<double> m_norms;
-    vector<int> m_row;
-    vector<int> m_col;
+    std::vector<int> m_row;
+    std::vector<int> m_col;
 signals:
 void statusBarUpdate(QString, int);
 public slots:

--- a/zernikesmoothingdlg.h
+++ b/zernikesmoothingdlg.h
@@ -35,7 +35,7 @@ private:
     double m_yCen;
     double m_rad;
     int m_originalSize;
-    vector<double> theZerns;
+    std::vector<double> theZerns;
 
     QTimer m_timer;
     wavefront *p_wf;


### PR DESCRIPTION
This is bad practice. Please never ever do `using namespace std;` again :)

I'm not removing for style but because it bytes me for what's coming next.