### PR TITLE
remove warnings from rule of 3/5/0

### DIFF
--- a/bezier.h
+++ b/bezier.h
@@ -159,11 +159,6 @@ namespace Bezier
                 this->normalize();
         }
 
-        Vec2(const Vec2& other)
-            : x(other.x)
-            , y(other.y)
-        {}
-
         Vec2(const Vec2& other, bool normalize)
             : Vec2(other.x, other.y, normalize)
         {}

--- a/wavefront.cpp
+++ b/wavefront.cpp
@@ -33,7 +33,8 @@ wavefront::~wavefront()
     nulledData.release();
 
 }
-wavefront::wavefront( wavefront &wf): data(wf.data.clone()),
+wavefront::wavefront( const wavefront &wf): 
+    data(wf.data.clone()),
     nulledData(wf.nulledData.clone()),
     mask(wf.mask.clone()),
     workData(wf.workData.clone()),

--- a/wavefront.h
+++ b/wavefront.h
@@ -25,7 +25,11 @@ class wavefront
 public:
     wavefront();
     ~wavefront();
-    wavefront( wavefront &wf);
+    wavefront( const wavefront &wf); // copy constructor doing deep copy of cv::Mat
+    wavefront( wavefront && ) = delete;	// move constructor, deleted because unused
+    wavefront& operator=( const wavefront & ) = default; // copy operator not doing deep copy of cv::mat
+    wavefront& operator=(wavefront &&) = delete; // move operator, deleted because unused
+
     cv::Mat_<double> data;
     cv::Mat_<double> nulledData;
     cv::Mat_<uint8_t> mask;


### PR DESCRIPTION
fix some [-Wdeprecated-copy] warnings only showing on newer compiler
https://en.cppreference.com/w/cpp/language/rule_of_three

For bezier.h, I noticed original repo and opened a PR there too https://github.com/oysteinmyrmo/bezier/pull/10
So our file would be identical to their latest version.

**as for wavefront, I fixed the warnings but not the code.**

copy constructor is not copying following fields and I'm not sure it's normal:
```
QString name;
QVector<std::vector<cv::Point> > regions;
bool regions_have_been_expanded;
```

Also the copy constructor does a deep copy of cv::Mat while the copy operator does not. I'm not sure this is OK or not. I suppose Dale took care of using `new` operator where he needed deep copy but I'm not sure this is correct approach.

Note that for the destructor, I think a default one would work fine. `clear` is supposed to be called automatically in cv::mat destructor.