### PR TITLE
Fixes GUI issues related to outline (oln) file (stores inner, outer, regions)

### DIFF
--- a/Circleoutline.h
+++ b/Circleoutline.h
@@ -24,6 +24,7 @@
 #include <QVector>
 #include <QPointF>
 #include <opencv2/opencv.hpp>
+#include <QJsonObject>
 void fillCircle(cv::Mat &m, double cx, double cy, double rad, void *color);
 class CircleOutline: public boundary
 {
@@ -31,6 +32,9 @@ class CircleOutline: public boundary
         CircleOutline();
         CircleOutline(QPointF center, double rad);
         CircleOutline(QPointF p1, QPointF p2);
+        CircleOutline(QJsonObject &obj);
+        void toJson(QJsonObject &obj);
+
         virtual ~CircleOutline();
         void draw(QPainter& painter, double scale, double scale2 = -1.);
         bool isInside(QPointF& p , int offset = 0);

--- a/Circleoutline.h
+++ b/Circleoutline.h
@@ -32,7 +32,7 @@ class CircleOutline: public boundary
         CircleOutline();
         CircleOutline(QPointF center, double rad);
         CircleOutline(QPointF p1, QPointF p2);
-        CircleOutline(QJsonObject &obj);
+        CircleOutline(const QJsonObject &obj);
         void toJson(QJsonObject &obj);
 
         virtual ~CircleOutline();

--- a/IgramArea.h
+++ b/IgramArea.h
@@ -146,9 +146,11 @@ public:
     void hideOutline(bool checked);
     bool m_hideOutlines;
     void loadOutlineFile(QString filename);
+    void loadJsonOutlineFile(QString filename);
     void undo();
     void redo();
     void writeOutlines(QString fileName);
+    void writeOutlinesold(QString fileName);
     QString makeOutlineName();
     void shiftoutline(QPointF p);
     void setZoomMode(zoomMode mode);

--- a/IgramArea.h
+++ b/IgramArea.h
@@ -146,7 +146,7 @@ public:
     void hideOutline(bool checked);
     bool m_hideOutlines;
     void loadOutlineFile(QString filename);
-    void loadJsonOutlineFile(QString filename);
+    void loadJsonOutlineFile(const QString filename);
     void undo();
     void redo();
     void writeOutlines(QString fileName);

--- a/circleoutline.cpp
+++ b/circleoutline.cpp
@@ -148,5 +148,12 @@ void CircleOutline::enlarge(int del) {
     m_p2.m_p.rx()+= del;
 }
 
+CircleOutline::CircleOutline(QJsonObject &obj) :
+    CircleOutline(QPointF(obj["center_x"].toDouble(), obj["center_y"].toDouble()), obj["radius_x"].toDouble()) {}
 
-
+void CircleOutline::toJson(QJsonObject &obj){
+    obj["center_x"]=m_center.x();
+    obj["center_y"]=m_center.y();
+    obj["radius_x"]=m_radius;
+    obj["radius_y"]=m_radius; // in case some day in the future we allow elliptical outlines the data format is ready to go
+}

--- a/circleoutline.cpp
+++ b/circleoutline.cpp
@@ -148,7 +148,7 @@ void CircleOutline::enlarge(int del) {
     m_p2.m_p.rx()+= del;
 }
 
-CircleOutline::CircleOutline(QJsonObject &obj) :
+CircleOutline::CircleOutline(const QJsonObject &obj) :
     CircleOutline(QPointF(obj["center_x"].toDouble(), obj["center_y"].toDouble()), obj["radius_x"].toDouble()) {}
 
 void CircleOutline::toJson(QJsonObject &obj){

--- a/graphicsutilities.cpp
+++ b/graphicsutilities.cpp
@@ -42,7 +42,7 @@ void writeCircle(std::ofstream& file, CircleOutline& circle){
     }
 }
 
-CircleOutline readCircle(std::ifstream &file){
+CircleOutline readCircle(std::ifstream &file, double x_offset, double y_offset){
     char buf[32 + 4];
     file.read(buf,8*4 + 4);
     if (!file){
@@ -66,8 +66,8 @@ CircleOutline readCircle(std::ifstream &file){
         file.read(buf,8);
     }
     CircleOutline c;
-    c.m_center.rx() = x;
-    c.m_center.ry() = y;
+    c.m_center.rx() = x + x_offset;
+    c.m_center.ry() = y + y_offset;
     c.m_radius = rx;
     c.m_p1.m_p.rx() = c.m_center.x() + c.m_radius;
     c.m_p2.m_p.rx() = c.m_center.x() - c.m_radius;

--- a/graphicsutilities.h
+++ b/graphicsutilities.h
@@ -25,6 +25,6 @@
 
 void drawPlus(QPointF p, QPainter& dc);
 
-CircleOutline readCircle(std::ifstream& file);
+CircleOutline readCircle(std::ifstream& file, double x_offset=0, double y_offset=0);
 void writeCircle(std::ofstream& file, CircleOutline &circle);
 #endif // GRAPHICSUTILITIES_H

--- a/igramarea.cpp
+++ b/igramarea.cpp
@@ -2102,7 +2102,7 @@ void IgramArea::CenterOutlineActive(bool checked){
     update();
 }
 
-void IgramArea::loadJsonOutlineFile(QString fileName){
+void IgramArea::loadJsonOutlineFile(const QString &fileName){
     QFile loadFile(fileName);
 
     if (!loadFile.open(QIODevice::ReadOnly)) {

--- a/igramarea.cpp
+++ b/igramarea.cpp
@@ -2414,7 +2414,7 @@ void IgramArea::writeOutlines(QString fileName){
     for (int i = 0; i < m_polygons.size(); ++ i){
         if (m_polygons[i].size() > 0){
             QJsonArray jPolygon;
-            for (unsigned int j = 0; j < m_polygons[i].size(); ++j){
+            for (std::size_t j = 0; j < m_polygons[i].size(); ++j){
                 QJsonObject jpoint;
                 jpoint["x"] = m_polygons[i][j].x+cropTotalDx;
                 jpoint["y"] = m_polygons[i][j].y+cropTotalDy;

--- a/igramarea.cpp
+++ b/igramarea.cpp
@@ -2142,10 +2142,10 @@ void IgramArea::loadJsonOutlineFile(const QString &fileName){
 
 
     // edge mask
-    QJsonValue jedge = loadDoc["edge_mask_width"];
+    const QJsonValue jedge = loadDoc["edge_mask_width"];
     mirrorDlg &md = *mirrorDlg::get_Instance();
     if (jedge.isDouble()) {
-        double edge = jedge.toDouble();
+        const double edge = jedge.toDouble();
         // if outline edge mask is different than current ask user
         if (edge != md.aperatureReduction){
             QString text(

--- a/igramarea.cpp
+++ b/igramarea.cpp
@@ -983,10 +983,6 @@ bool IgramArea::openImage(const QString &fileName, bool showBoundary)
         Mat distortion =Mat::zeros(1,5, CV_64FC1);
         camera.at<double>(0,0) = parms[6].toDouble();
         camera.at<double>(1,1) = camera.at<double>(0,0);
-        //double width = camera.at<double>(0,2) = parms[7].toDouble();
-        //double height = camera.at<double>(1,2) = parms[8].toDouble();
-        //width *= 2;
-        //height *= 2;
 
         for (int i = 0; i < 5; ++i){
             distortion.at<double>(0,i) = parms[1 + i].toDouble();
@@ -2102,7 +2098,7 @@ void IgramArea::CenterOutlineActive(bool checked){
     update();
 }
 
-void IgramArea::loadJsonOutlineFile(const QString &fileName){
+void IgramArea::loadJsonOutlineFile(const QString fileName){
     QFile loadFile(fileName);
 
     if (!loadFile.open(QIODevice::ReadOnly)) {
@@ -2142,7 +2138,7 @@ void IgramArea::loadJsonOutlineFile(const QString &fileName){
 
 
     // edge mask
-    const QJsonValue jedge = loadDoc["edge_mask_width"];
+    const QJsonValue jedge = loadDoc["edge_mask_width_mm"];
     mirrorDlg &md = *mirrorDlg::get_Instance();
     if (jedge.isDouble()) {
         const double edge = jedge.toDouble();
@@ -2171,6 +2167,7 @@ void IgramArea::loadJsonOutlineFile(const QString &fileName){
 
                 break;
             case QMessageBox::No:
+            default: // if they click red X do same thing as "no" button
                 md.changeEdgeMaskvalues(md.aperatureReduction);
                 break;
             }
@@ -2406,7 +2403,7 @@ void IgramArea::writeOutlines(QString fileName){
 
     if (m_edgeMaskWidth != 0) {
         mirrorDlg &md = *mirrorDlg::get_Instance();
-        j1["edge_mask_width"] = md.aperatureReduction;
+        j1["edge_mask_width_mm"] = md.aperatureReduction;
     }
 
     QJsonArray jRegions;

--- a/igramarea.cpp
+++ b/igramarea.cpp
@@ -2137,9 +2137,8 @@ void IgramArea::loadJsonOutlineFile(const QString &fileName){
         innerPcount = 2;
     }
 
-    // filter
-    double filt = loadDoc["dft_filter_radius"].toDouble();
-    emit dftCenterFilter(filt);
+    const double filter = loadDoc["dft_filter_radius"].toDouble();
+    emit dftCenterFilter(filter);
 
 
     // edge mask

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -491,7 +491,7 @@ void MainWindow::createDockWindows(){
     m_contourTools->setAllowedAreas(Qt::LeftDockWidgetArea | Qt::RightDockWidgetArea);
     m_dftTools->setAllowedAreas(Qt::LeftDockWidgetArea | Qt::RightDockWidgetArea);
     metrics = metricsDisplay::get_instance(this);
-    metrics->setWindowTitle(QString("metrics      DFTFringe %s").arg(APP_VERSION));
+    metrics->setWindowTitle(QString("metrics      DFTFringe %1").arg(APP_VERSION));
     zernTablemodel = metrics->tableModel;
     addDockWidget(Qt::LeftDockWidgetArea, m_outlineHelp);
     addDockWidget(Qt::LeftDockWidgetArea, m_outlinePlots);

--- a/zernikeprocess.cpp
+++ b/zernikeprocess.cpp
@@ -826,6 +826,10 @@ void zernikeProcess::fillVoid(wavefront &wf){
         int endx = x;
         int starty = y;
         int endy = y;
+        qDebug() << "regions to fill: " << wf.regions.size();
+        for (int z = 0; z < m_norms.size(); ++z){
+            qDebug() << "zern "<< z << " " << wf.InputZerns[z];
+        }
         for (int n = 0; n < wf.regions.size(); ++n){
 
             for (int i = 0; i < wf.regions[n].size(); ++i){


### PR DESCRIPTION
Fixes #19  and more:
- Fixed bug where oln files can be read wrong (typically 12% of the time) and
  the fix involved creating a new json based oln format.  Old oln file formats
  are detected and are still read using the "older" oln reading code.
- Other outline and region related GUI bugs
- Fixed bug where reading and writing to oln file after cropping was using
  the wrong x,y values.  Works great now.
- Fixed minor bug recently introduced where it stopped showing the version 
  number in the metrics window (top of panel where it shows RMS error).
- Added some debugging code to zernikeprocess.cpp to try to nail down a rare, 
  intermittent bug where regions are filled with the wrong zernike values somehow.  
  It happens so rarely that I'm just going to leave the debugging code in until it 
  happens again.

