### PR TITLE
fixClazy warnings

### DIFF
--- a/astigstatsdlg.cpp
+++ b/astigstatsdlg.cpp
@@ -258,15 +258,16 @@ void astigStatsDlg::plot(){
     double ymax = -1000;
     int colorndx = 0;
     QMap<QString, QPointF> means;
-    foreach(QString name, groups.keys()){
-        int size = groups[name].size();
+    for(auto it = groups.cbegin() ; it != groups.cend() ; it++){
+        QString name = it.key();
+        const int size = it.value().size();
         double *xAstig = new double[size];
         double *yAstig = new double[size];
         RunningStat xstats, ystats;
 
         QColor color = QColor(Qt::GlobalColor( 7 + colorndx%12 ));
         QVector<QPointF> points;
-        foreach (measure data, groups[name]){
+        foreach (const measure &data, it.value()){
             xAstig[i] = data.p.x();
             points << QPointF(data.p.x(), data.p.y());
             xstats.Push(xAstig[i]);
@@ -389,11 +390,9 @@ void astigStatsDlg::plot(){
     if (ui->bestFitCB->isChecked()){
         double *xvals = new double[means.size()];
         double *yvals = new double[means.size()];
-        int i = 0;
-        foreach(QString name, means.keys()){
-            xvals[i] = means[name].x();
-            yvals[i] = means[name].y();
-            ++i;
+        for(const QPointF &value: qAsConst(means)){
+            xvals[i] = value.x();
+            yvals[i] = value.y();
         }
 
         CircleData d(means.size(), xvals, yvals);
@@ -799,10 +798,10 @@ void astigStatsDlg::on_distribution_clicked()
         html.append("<p><img src='" +imageName + "'/></p>");
     }
     // for each group
-    foreach(QString Name, groups.keys()){
-
-        QList<QPointF> items = groups[Name];
-        int size = items.size();
+    for(auto it=groups.cbegin() ; it!=groups.cend() ; it++){
+        const QList<QPointF> items = it.value();
+        const QString Name = it.key();
+        const int size = items.size();
         float *xAstig = new float[size];
         float *yAstig = new float[size];
         for (int i = 0; i < size; ++i){

--- a/astigstatsdlg.cpp
+++ b/astigstatsdlg.cpp
@@ -390,9 +390,11 @@ void astigStatsDlg::plot(){
     if (ui->bestFitCB->isChecked()){
         double *xvals = new double[means.size()];
         double *yvals = new double[means.size()];
+        int i = 0;
         for(const QPointF &value: qAsConst(means)){
             xvals[i] = value.x();
             yvals[i] = value.y();
+            ++i;
         }
 
         CircleData d(means.size(), xvals, yvals);

--- a/nullvariationdlg.cpp
+++ b/nullvariationdlg.cpp
@@ -117,22 +117,23 @@ void nullVariationDlg::on_diameterDelta_valueChanged(double val)
     set.setValue("nullDiamTol", ((isMm) ? 1. : 25.4) * val);
     calculate();
 }
+
 #include <qmap.h>
 #include <qwt_plot_histogram.h>
+
 QMap<double,int > histo(const QList<double> data, int bins){
     auto minma = std::minmax_element( data.begin(), data.end());
     double range = *minma.second - *minma.first;
     double histInterval = range/bins;
     QMap<double,int> intervals;
-    for (int i = 0; i < bins; ++i)
+    for (int i = 1; i <= bins; ++i)
     {
-        intervals[ *minma.first + histInterval * (i+1)] = 0;
+        intervals[ *minma.first + histInterval * i] = 0;
     }
-    QVector<double> keys = intervals.keys().toVector();
     for (int i = 0; i < data.size(); ++i){
-        for (int j = 0; j < bins; ++j){
-            if (data[i]<= keys[j]) {
-                ++intervals[keys[j]];
+        for(auto it=intervals.begin() ; it!=intervals.end() ; it++){
+            if (data[i]<= it.key()) {
+                it.value()++;
                 break;
             }
         }

--- a/surfacemanager.cpp
+++ b/surfacemanager.cpp
@@ -1525,9 +1525,10 @@ void SurfaceManager::average(QList<wavefront *> wfList){
     QString maxkey;
     qDebug() << "sizes" << sizes;
 
-    foreach(QString v, sizes.keys()){
-        int a = sizes[v].length();
+    for(auto it = sizes.cbegin() ; it!=sizes.cend() ; it++){
+        const int a = it.value().length();
         if (a > max) {
+            const QString v = it.key();
             max = a;
             maxkey = v;
             qDebug() << "max" << v << max;

--- a/wftstats.cpp
+++ b/wftstats.cpp
@@ -270,11 +270,11 @@ void wftStats::computeWftRunningAvg( QVector<wavefront*> wavefronts, int ndx){
     }
     int max = 0;
     QString maxkey;
-    foreach(QString v, sizes.keys()){
-        int a = sizes[v];
+    for(auto it=sizes.cbegin() ; it!=sizes.cend() ; it++){
+        const int a = it.value();
         if (a > max) {
             max = a;
-            maxkey = v;
+            maxkey = it.key();
         }
     }
     int rrows, rcols;


### PR DESCRIPTION
fix 6 occurences of `[-Wclazy-container-anti-pattern]`
I removed foreach loop each time because it's not recommended anyway anymore.

I tested the impact on the different windows except "artificial null error margin" (nullvariationdlg) as I did not understand how to use it.  I have seen no obvious effect.