### PR TITLE
[bug] fix some memory leaks

### DIFF
--- a/contourplot.cpp
+++ b/contourplot.cpp
@@ -548,13 +548,6 @@ void ContourPlot::showSpectrogram(bool on )
     d_spectrogram->setDisplayMode( QwtPlotSpectrogram::ImageMode, on );
     d_spectrogram->setDefaultContourPen(m_do_fill ? QPen(m_contourPen) : QPen(Qt::NoPen));
 
-    //TODO JST 20230815 commented this code because seems to have no purpose. Remove if this is confirmed
-    //QwtPlotShapeItem *item = new QwtPlotShapeItem( "" );
-    //item->setItemAttribute( QwtPlotItem::Legend, true );
-    //item->setLegendMode( QwtPlotShapeItem::LegendShape );
-    //item->setLegendIconSize( QSize( 20, 20 ) );
-    //item->setRenderHint( QwtPlotItem::RenderAntialiased, true );
-
     replot();
 }
 

--- a/contourplot.cpp
+++ b/contourplot.cpp
@@ -548,11 +548,12 @@ void ContourPlot::showSpectrogram(bool on )
     d_spectrogram->setDisplayMode( QwtPlotSpectrogram::ImageMode, on );
     d_spectrogram->setDefaultContourPen(m_do_fill ? QPen(m_contourPen) : QPen(Qt::NoPen));
 
-    QwtPlotShapeItem *item = new QwtPlotShapeItem( "" );
-    item->setItemAttribute( QwtPlotItem::Legend, true );
-    item->setLegendMode( QwtPlotShapeItem::LegendShape );
-    item->setLegendIconSize( QSize( 20, 20 ) );
-    item->setRenderHint( QwtPlotItem::RenderAntialiased, true );
+    //TODO JST 20230815 commented this code because seems to have no purpose. Remove if this is confirmed
+    //QwtPlotShapeItem *item = new QwtPlotShapeItem( "" );
+    //item->setItemAttribute( QwtPlotItem::Legend, true );
+    //item->setLegendMode( QwtPlotShapeItem::LegendShape );
+    //item->setLegendIconSize( QSize( 20, 20 ) );
+    //item->setRenderHint( QwtPlotItem::RenderAntialiased, true );
 
     replot();
 }

--- a/dftarea.cpp
+++ b/dftarea.cpp
@@ -110,7 +110,7 @@ DFTArea::DFTArea(QWidget *mparent, IgramArea *ip, DFTTools * tools, vortexDebug 
     m_PSIstate = 0;
     QRect rec = QGuiApplication::primaryScreen()->geometry();
 
-    m_Psidlg = new PSI_dlg;
+    m_Psidlg = new PSI_dlg(this);
     rec.setLeft(rec.width()/6);
     rec.setTop(rec.height()/4);
     rec.setWidth(rec.width()/4);

--- a/dftarea.cpp
+++ b/dftarea.cpp
@@ -627,10 +627,6 @@ cv::Mat DFTArea::vortex(QImage &img, double low)
     double *qmap = new double[size];
     double *orient = new double[size];
 
-
-    double *imRe = new double[size];
-
-
     //double *fdom[2]; fdom[0] = new double[size]; fdom[1] = new double[size];
     double *d1[2]; d1[0] = new double[size]; d1[1] = new double[size];
     double *d2[2]; d2[0] = new double [size]; d2[1] = new double [size];
@@ -639,17 +635,17 @@ cv::Mat DFTArea::vortex(QImage &img, double low)
     double *spiralIm = new double[size];
 
 
-
-
-
     if (m_vortexDebugTool->m_showInput){
-        cv::Mat tmp = cv::Mat(ysize,xsize,numType, imRe);
-        cv::Mat xx;
-        tmp.convertTo(xx,CV_32F);
-        cv::imshow("input", xx);
-        cv::waitKey(1);
+        double *imReTmp = new double[size];
+        {
+            cv::Mat tmp = cv::Mat(ysize,xsize,numType, imReTmp);
+            cv::Mat xx;
+            tmp.convertTo(xx,CV_32F);
+            cv::imshow("input", xx);
+            cv::waitKey(1);
+        } // delete imReTmp after tmp is destructed by end of scope
+        delete[] imReTmp;
     }
-
 
     cv::Mat fdomMat;
     cv::Mat fdomPlanes[2];
@@ -738,7 +734,7 @@ cv::Mat DFTArea::vortex(QImage &img, double low)
 
     imPlanes[1] *= 0.;
 
-    imRe = (double *)(imPlanes[0].data);
+    double *imRe = (double *)(imPlanes[0].data);
     if (0) { //(0 == strcmp (what, "im2")) {
         showData("im border added", imPlanes[0].clone());
     }

--- a/igramarea.cpp
+++ b/igramarea.cpp
@@ -109,7 +109,7 @@ IgramArea::IgramArea(QWidget *parent, void *mw)
     opacity = set.value("igramLineOpacity", 65.).toDouble();
     lineStyle = set.value("igramLineStyle", 1).toInt();
     setMouseTracking(true);
-    m_dftThumb = new dftThumb();
+    m_dftThumb = new dftThumb(this);
     m_dftThumb->setWindowFlags(    Qt::WindowStaysOnTopHint);
     m_outlineTimer = new QTimer(this);
     connect(m_outlineTimer, SIGNAL(timeout()),this, SLOT(outlineTimerTimeout()));

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -85,9 +85,9 @@ MainWindow::MainWindow(QWidget *parent) :
     ui->SelectOutSideOutline->setChecked(true);
     setCentralWidget(ui->tabWidget);
 
-    m_colorChannels = new ColorChannelDisplay();
+    m_colorChannels = new ColorChannelDisplay(this);
 
-    m_intensityPlot = new igramIntensity(0);
+    m_intensityPlot = new igramIntensity(this);
 
     ui->tabWidget->removeTab(0);
     ui->tabWidget->removeTab(0);

--- a/mirrordlg.cpp
+++ b/mirrordlg.cpp
@@ -118,7 +118,7 @@ mirrorDlg::mirrorDlg(QWidget *parent) :
 
 mirrorDlg::~mirrorDlg()
 {
-
+    delete ui;
 }
 bool mirrorDlg::shouldFlipH(){
     return ui->flipH->isChecked();

--- a/profileplot.cpp
+++ b/profileplot.cpp
@@ -215,6 +215,11 @@ ProfilePlot::ProfilePlot(QWidget *parent , ContourTools *tools):
     ui->setupUi(this);
     populate();
 }
+
+ProfilePlot::~ProfilePlot(){
+    delete ui;
+}
+
 void ProfilePlot::showSlope(bool val){
     m_showSlopeError = val;
     if (!val)

--- a/profileplot.h
+++ b/profileplot.h
@@ -42,6 +42,7 @@ public:
     QwtPlot *m_plot;
     wavefront* m_wf;
     ProfilePlot( QWidget *parent = NULL, ContourTools* tools = 0 );
+    ~ProfilePlot();
     QVector<wavefront*> *wfs;
     void setSurface(wavefront * wf);
     virtual void resizeEvent( QResizeEvent * );

--- a/punwrap.cpp
+++ b/punwrap.cpp
@@ -384,7 +384,7 @@ void unwrap(double * pphase, double *punwrapped, char* bflags, int nx, int ny)
     unwrapped = punwrapped;
     phase = pphase;
 
-  int size = xsize * ysize;
+  const int size = xsize * ysize;
   flags = bflags;
 
 
@@ -396,10 +396,14 @@ void unwrap(double * pphase, double *punwrapped, char* bflags, int nx, int ny)
    if (g_qqmap)
     delete[] g_qqmap;
 
-  g_qqmap = qmap = new double[nx * ny];
+  g_qqmap = qmap = new double[size];
   memset(qmap,0, sizeof(double)*size);
 
-  path = new double[nx * ny];
+  // TODO JST 20230815 this limits memory leak but should be refactored with a object oriented programming
+  if(path){
+    delete[] path;
+  }
+  path = new double[size];
   memset(path,0,sizeof(double)*size);
 
   dv_quality_map(pphase, 5, qmap, nx, ny);

--- a/settings2.cpp
+++ b/settings2.cpp
@@ -47,13 +47,10 @@ Settings2::Settings2(QWidget *parent) :
     ui->stackedWidget->addWidget(m_debug);
 
 }
-Settings2 *Settings2::m_Instance = NULL;
-Settings2 *Settings2::getInstance(){
-    if (m_Instance == NULL) {
-        m_Instance = new Settings2(0);
 
-    }
-     return m_Instance;
+Settings2 *Settings2::getInstance(){
+    static Settings2 m_Instance{};
+    return &m_Instance;
 }
 
 Settings2::~Settings2()

--- a/settings2.cpp
+++ b/settings2.cpp
@@ -17,6 +17,7 @@
 ****************************************************************************/
 #include "settings2.h"
 #include "ui_settings2.h"
+#include <QDebug>
 
 settingsIGram *Settings2::m_igram = 0;
 settingsDFT *Settings2::m_dft = 0;
@@ -58,6 +59,7 @@ Settings2 *Settings2::getInstance(){
 Settings2::~Settings2()
 {
     delete ui;
+    qDebug() << "Settings2::~Settings2";
 }
 
 

--- a/settings2.h
+++ b/settings2.h
@@ -33,9 +33,11 @@ class Settings2 : public QDialog
     Q_OBJECT
 
 public:
-    explicit Settings2(QWidget *parent = 0);
     static Settings2 *getInstance();
+    Settings2(const Settings2&) = delete;
+    Settings2& operator=(const Settings2&) = delete;
     ~Settings2();
+
     static settingsIGram *m_igram;
     static settingsDFT *m_dft;
     static settingsDebug *m_debug;
@@ -50,8 +52,8 @@ private slots:
     void on_listWidget_clicked(const QModelIndex &index);
 
 private:
+    explicit Settings2(QWidget *parent = 0);
     Ui::Settings2 *ui;
-    static Settings2 * m_Instance;
 };
 
 #endif // SETTINGS2_H

--- a/surfacemanager.cpp
+++ b/surfacemanager.cpp
@@ -543,7 +543,13 @@ SurfaceManager::SurfaceManager(QObject *parent, surfaceAnalysisTools *tools,
     initWaveFrontLoad();
 }
 
-SurfaceManager::~SurfaceManager(){qDebug() << "SurfaceManager::~SurfaceManager";}
+SurfaceManager::~SurfaceManager(){
+    qDebug() << "SurfaceManager::~SurfaceManager";
+    for(wavefront* wf : m_wavefronts){
+        delete wf;
+    }
+}
+
 void SurfaceManager::outputLambdaChanged(double val){
     outputLambda = val;
     computeZerns();

--- a/surfacemanager.cpp
+++ b/surfacemanager.cpp
@@ -543,7 +543,7 @@ SurfaceManager::SurfaceManager(QObject *parent, surfaceAnalysisTools *tools,
     initWaveFrontLoad();
 }
 
-SurfaceManager::~SurfaceManager(){}
+SurfaceManager::~SurfaceManager(){qDebug() << "SurfaceManager::~SurfaceManager";}
 void SurfaceManager::outputLambdaChanged(double val){
     outputLambda = val;
     computeZerns();


### PR DESCRIPTION
I run Valgrind on Linux using QTcreator. Running the tool is really straightforward but incredibly slow. And you need to do every actions you would do as end user so that the actual leak is shown. This is not static analysis. And after analysis you need to actually fix the code and test again.  
There were 2 actual/growing leaks that are fixed. The rest is cleanup to reduce tool noise because too much warnings is always masking real problems. Maybe they did actual leaks.  
One of the main problems is that [object tree](https://doc.qt.io/qt-6/objecttrees.html) is not built correctly so the objects don't know when to be deleted. Of course if they exist only once, leak will not grow but this still makes noise during analysis so it must be implemented.

About contourplot.cpp, I only commented out. I need your feedback on this as I'm not experienced enough in QT and QWT.

About singleton, the C++11 way is actually cleaner and will call destructor at end of program. This helps removing noise. I recommend to update all singleton instances in the tool (I counted 15 singleton objects with `get_Instance`, `getInstance` and `get_instance` ...)
Please read https://leimao.github.io/blog/CPP-Singleton/

This would also have saved some leaks if it existed before. Enjoy the reading : https://en.cppreference.com/w/cpp/memory/unique_ptr

@githubdoe To simplify review I prefer to do many small PR instead of one big. And even like that, I recommend you look at each commit individually to simplify review. 
Also please take your time for the reviews, there is no urgency.

Sorry, the explanation was already longer than I expected. Do not hesitate if you have any remark or question.