### PR TITLE
[bug] fix change in window behavior introduced in 90f7bbd

### DIFF
--- a/dftarea.cpp
+++ b/dftarea.cpp
@@ -110,7 +110,7 @@ DFTArea::DFTArea(QWidget *mparent, IgramArea *ip, DFTTools * tools, vortexDebug 
     m_PSIstate = 0;
     QRect rec = QGuiApplication::primaryScreen()->geometry();
 
-    m_Psidlg = new PSI_dlg(this);
+    m_Psidlg = new PSI_dlg(nullptr);
     rec.setLeft(rec.width()/6);
     rec.setTop(rec.height()/4);
     rec.setWidth(rec.width()/4);
@@ -213,6 +213,7 @@ bool DFTArea::eventFilter(QObject * /*obj*/, QEvent *event) {
 }
 DFTArea::~DFTArea()
 {
+    delete m_Psidlg;
     delete ui;
 }
 void DFTArea::setChannel(const QString& val){
@@ -1136,7 +1137,6 @@ void DFTArea::outlineDoneSig(){
 }
 #include "psiphasedisplay.h"
 void DFTArea::doPSIstep1(){
-    //m_Psidlg = new Psidlg;
     if (!doPSIstep2())
         return;
     if (m_psiFiles.size() == 0)

--- a/dftthumb.ui
+++ b/dftthumb.ui
@@ -17,7 +17,7 @@
    <item>
     <widget class="QLabel" name="label">
      <property name="text">
-      <string>TextLabel</string>
+      <string/>
      </property>
     </widget>
    </item>

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -85,9 +85,9 @@ MainWindow::MainWindow(QWidget *parent) :
     ui->SelectOutSideOutline->setChecked(true);
     setCentralWidget(ui->tabWidget);
 
-    m_colorChannels = new ColorChannelDisplay(this);
+    m_colorChannels = new ColorChannelDisplay(nullptr);
 
-    m_intensityPlot = new igramIntensity(this);
+    m_intensityPlot = new igramIntensity(nullptr);
 
     ui->tabWidget->removeTab(0);
     ui->tabWidget->removeTab(0);
@@ -310,6 +310,8 @@ void MainWindow::closeEvent(QCloseEvent *event)
 MainWindow::~MainWindow()
 {
     qDebug() << "deleteing mainwindow";
+    delete m_colorChannels;
+    delete m_intensityPlot;
     delete m_ogl;
     delete ui;
 }

--- a/res/Help/PSIHelp.html
+++ b/res/Help/PSIHelp.html
@@ -39,7 +39,7 @@ All interferograms must have the mirror in the same spot and be same size image 
 This will then set the phase for each image after it is loaded. If you do not know it then ignore that field and select
 the <b>"Phase is approximate or unknown radio button"</b>.</li>
 <li>Select "Browse" to add list of interferograms"</li>
-<li>If phase is unknown press the <b>"Compute Phases"</b> button.  That button will show only if you have selected <b>"Pahse is approxiamte or unknown"</b>.
+<li>If phase is unknown press the <b>"Compute Phases"</b> button.  That button will show only if you have selected <b>"Phase is approxiamte or unknown"</b>.
 <li>Phases will be computed and refined by an iterative process that hopefully will converd.</li>
 <li>Review the phase plot graph to see if it is reasonable.  The phase angle and the difference from the previous interferogram is plotted on a spiral."</li>
 <li>Press the <b>"Phase is known"</b> radio button and then press OK to compute the surface."</li>

--- a/todo.txt
+++ b/todo.txt
@@ -1,6 +1,0 @@
-
-
-
-Regions is not save correctly or at least read back correctly.
-
-out of border region causes crash.


### PR DESCRIPTION
- `igramIntensity` `ColorChannelDisplay` `PSI_dlg` I removed the this as they are actual dialog my understanding is that they should either be modal and have a parent or not be modal and not have parent 

Documentation states 
> The parent relationship of the dialog does not imply that the dialog will always be stacked on top of the parent window

But I searched a lot and I did not find how to use parent, be non-modal and not always stay on top alltogether
It's probably better as it is now. And I agree with Dale, `igramIntensity` `ColorChannelDisplay` windows should not be modal. They are updated on the fly during process and modal would lock out user.
For `PSI_dlg` however, maybe it should be full modal. I let you think about it as I have no experience with the PSI_dlg usage.

Also about calling the destructor, it does not only free memory properly but also makes sure the windows are closed when mainWindow is closed. Dialog staying open was a bug already present in 6.2 and 6.3.1. Thanks Georges for pointing it out. Maybe add it to release note.

- `dftthumb` I only changed the display as it should probably have a parent, not like the other windows