### PR TITLE
[bug fix] "show only average" in astig stats wasn't removing display

### DIFF
--- a/astigstatsdlg.cpp
+++ b/astigstatsdlg.cpp
@@ -173,8 +173,6 @@ astigStatsDlg::astigStatsDlg(QVector<wavefront *> wavefronts, QWidget *parent) :
 
 astigStatsDlg::~astigStatsDlg()
 {
-    delete zoomer; //TODO JST 2023/08/30 check if delete is needed. I don't think so because the parent is set
-
     delete ui;
 }
 class measure{

--- a/astigstatsdlg.cpp
+++ b/astigstatsdlg.cpp
@@ -168,7 +168,6 @@ astigStatsDlg::astigStatsDlg(QVector<wavefront *> wavefronts, QWidget *parent) :
     ui->mPlot->setPalette( Qt::white );
 
     ui->bestFitCB->hide();
-    dplot = new QwtPlot;  //TODO JST 2023/09/01  unused ?
     plot();
 }
 

--- a/astigstatsdlg.h
+++ b/astigstatsdlg.h
@@ -13,6 +13,7 @@ class Zoomer;
 class QTextEdit;
 class QVBoxLayout;
 class QHBoxLayout;
+class CustomPlotPicker;
 namespace Ui {
 
 class astigStatsDlg;
@@ -65,6 +66,7 @@ private:
     QVBoxLayout *layout;
     QHBoxLayout *toolLayout;
     bool m_usePolar;
+    CustomPlotPicker *picker;
 };
 
 #endif // ASTIGSTATSDLG_H

--- a/astigstatsdlg.h
+++ b/astigstatsdlg.h
@@ -50,7 +50,6 @@ private slots:
 
 private:
     int mndx;
-    QwtPlot *dplot;
     QVector<QStringList> m_zerns;
     Zoomer *zoomer;
     Ui::astigStatsDlg *ui;


### PR DESCRIPTION
I'm getting better at QWT and QT. Thank chatGPT on this one also.

fix #85 by using QWTplotPicker to display what we need to. I have been able to fix the bug and still keep the feature.
Moving mouse +/-5 pixels around the data will display the wavefront name