### PR TITLE
[feature] Enter displays wavefront. Double click and F2 rename from the start

### DIFF
--- a/surfaceanalysistools.cpp
+++ b/surfaceanalysistools.cpp
@@ -56,8 +56,8 @@ surfaceAnalysisTools::surfaceAnalysisTools(QWidget *parent) :
     connect(ui->wavefrontList->itemDelegate(), SIGNAL(closeEditor(QWidget*, QAbstractItemDelegate::EndEditHint)), this,
             SLOT(ListWidgetEditEnd(QWidget*, QAbstractItemDelegate::EndEditHint)));
     ui->wavefrontList->setContextMenuPolicy(Qt::CustomContextMenu);
-    QShortcut* dellShortcut = new QShortcut(Qt::Key_Delete, this);
-    connect(dellShortcut, &QShortcut::activated, this, &surfaceAnalysisTools::on_deleteWave_clicked);
+    QShortcut* delShortcut = new QShortcut(Qt::Key_Delete, this);
+    connect(delShortcut, &QShortcut::activated, this, &surfaceAnalysisTools::on_deleteWave_clicked);
 }
 
 void surfaceAnalysisTools::enableControls(bool flag){
@@ -107,7 +107,7 @@ void surfaceAnalysisTools::on_spinBox_2_valueChanged(int arg1)
     emit centerMaskValue(arg1);
 }
 
-// this is responsible of givin user feedback about which wft is currently displayed
+// this is responsible of giving user feedback about which wft is currently displayed
 void surfaceAnalysisTools::currentNdxChanged(int ndx){
     if (ui->wavefrontList->count() == 0)
         return;

--- a/surfaceanalysistools.cpp
+++ b/surfaceanalysistools.cpp
@@ -17,7 +17,9 @@
 ****************************************************************************/
 #include "surfaceanalysistools.h"
 #include "ui_surfaceanalysistools.h"
+#include <QAction>
 #include <QDebug>
+#include <QMenu>
 #include <QSettings>
 #include <QtAlgorithms>
 #include <QLineEdit>
@@ -73,9 +75,8 @@ void surfaceAnalysisTools::addWaveFront(const QString &name){
         shorter = list[list.size()-2] + "/" + list[list.size()-1];//fontMetrics().elidedText(name,Qt::ElideLeft,w);
 
     ui->wavefrontList->addItem(shorter);
-    lastCurrentItem = ui->wavefrontList->count()-1;
+    currentNdxChanged(ui->wavefrontList->count()-1);
     ui->wavefrontList->item(lastCurrentItem)->setFlags(Qt::ItemIsEditable | Qt::ItemIsEnabled | Qt::ItemIsSelectable);
-
 }
 
 void surfaceAnalysisTools::removeWaveFront(const QString &){
@@ -93,12 +94,6 @@ void surfaceAnalysisTools::on_blurCB_clicked(bool checked)
     emit surfaceSmoothGBEnabled(checked);
 }
 
-void surfaceAnalysisTools::on_wavefrontList_itemDoubleClicked(QListWidgetItem *item)
-{
-    ui->wavefrontList->editItem(item);
-    emit wavefrontDClicked(item->text());
-}
-
 void surfaceAnalysisTools::on_spinBox_valueChanged(int arg1)
 {
     emit outsideMaskValue(arg1);
@@ -109,49 +104,74 @@ void surfaceAnalysisTools::on_spinBox_2_valueChanged(int arg1)
     emit centerMaskValue(arg1);
 }
 
- void surfaceAnalysisTools::currentNdxChanged(int ndx){
-     if (ui->wavefrontList->count() == 0)
-         return;
+// this is responsible of givin user feedback about which wft is currently displayed
+void surfaceAnalysisTools::currentNdxChanged(int ndx){
+    if (ui->wavefrontList->count() == 0)
+        return;
 
-     QListWidgetItem *item = ui->wavefrontList->currentItem();
-     if (item)
-         item->setForeground(Qt::gray);
-     ui->wavefrontList->setCurrentRow(ndx,QItemSelectionModel::Current);
-     item = ui->wavefrontList->currentItem();
-     item->setForeground(Qt::black);
-     lastCurrentItem = ui->wavefrontList->currentRow();
+    QListWidgetItem *item = ui->wavefrontList->item(lastCurrentItem);
+    if (item){
+        item->setIcon(style()->standardIcon(QStyle::SP_CustomBase));
+    }
+    ui->wavefrontList->setCurrentRow(ndx,QItemSelectionModel::Current);
 
+    item = ui->wavefrontList->currentItem();
+    item->setIcon(style()->standardIcon(QStyle::SP_DialogYesButton));
 
- }
+    lastCurrentItem = ui->wavefrontList->currentRow();
+}
+
 void surfaceAnalysisTools::deleteWaveFront(int i){
     QListWidgetItem* item = ui->wavefrontList->takeItem(i);
     delete item;
-
 }
 
-// thiis is called when pressing enter on a wevefront selected with arrow key
+// this is called when pressing enter on a wavefront selected with arrow key
 void surfaceAnalysisTools::on_wavefrontList_activated(const QModelIndex &index)
 {
     on_wavefrontList_clicked(index);
 }
 void surfaceAnalysisTools::on_wavefrontList_clicked(const QModelIndex &index)
 {
-    QListWidgetItem *item = ui->wavefrontList->item(lastCurrentItem);
-    if (item)
-        item->setForeground(Qt::gray);
-
-    QModelIndexList indexes = ui->wavefrontList->selectionModel()->selectedIndexes();
-
     /*
+    QModelIndexList indexes = ui->wavefrontList->selectionModel()->selectedIndexes();
     foreach(QModelIndex index, indexes)
     {
         emit waveFrontClicked(index.row());
     }
             */
-    // only enform about the last item in the list for efficency.
+    // only inform about the clicked item in the list for efficency.
     //That way surface manager does not spend time updating things not shown.
-    emit waveFrontClicked(indexes.last().row());
-    currentNdxChanged(index.row());
+    emit waveFrontClicked(index.row());
+}
+
+// this is "right click" on windows
+void surfaceAnalysisTools::on_wavefrontList_customContextMenuRequested(const QPoint &pos)
+{
+    QListWidgetItem *item = ui->wavefrontList->itemAt(pos);
+    if (item == 0)
+        return;
+
+    QMenu contextMenu(this);
+
+    // Create "Delete" action
+    QAction *deleteAction = new QAction("Delete", this);
+    connect(deleteAction, &QAction::triggered, [this, item]() {
+        on_deleteWave_clicked();
+    });
+    contextMenu.addAction(deleteAction);
+
+    // Create "Rename" action
+    QAction *renameAction = new QAction("Rename", this);
+    connect(renameAction, &QAction::triggered, [this, item]() {
+        ui->wavefrontList->editItem(item);
+    });
+    contextMenu.addAction(renameAction);
+
+    // TODO later add "invert" and "rotate"
+
+    // Show the context menu at the cursor position
+    contextMenu.exec(ui->wavefrontList->mapToGlobal(pos));
 }
 
 QList<int> surfaceAnalysisTools::SelectedWaveFronts(){
@@ -248,16 +268,6 @@ void surfaceAnalysisTools::defocusControlChanged(double val){
 void surfaceAnalysisTools::on_InvertPB_pressed()
 {
     emit invert(SelectedWaveFronts());
-}
-
-// this is "right click" on windows
-void surfaceAnalysisTools::on_wavefrontList_customContextMenuRequested(const QPoint &pos)
-{
-    QListWidgetItem *item = ui->wavefrontList->itemAt(pos);
-    if (item == 0)
-        return;
-    item->setSelected(true);	// even a right click will select the item
-    ui->wavefrontList->editItem(item);
 }
 
 void surfaceAnalysisTools::ListWidgetEditEnd(QWidget *editor, QAbstractItemDelegate::EndEditHint ){

--- a/surfaceanalysistools.cpp
+++ b/surfaceanalysistools.cpp
@@ -66,7 +66,7 @@ void surfaceAnalysisTools::enableControls(bool flag){
 void surfaceAnalysisTools::setBlurText(QString txt){
     ui->blurMm->setText(txt);
 }
-void ListWidgetEditEnd(QWidget *editor, QAbstractItemDelegate::EndEditHint hint);
+
 void surfaceAnalysisTools::addWaveFront(const QString &name){
 
     QStringList list = name.split('/');
@@ -270,13 +270,19 @@ void surfaceAnalysisTools::on_InvertPB_pressed()
     emit invert(SelectedWaveFronts());
 }
 
-void surfaceAnalysisTools::ListWidgetEditEnd(QWidget *editor, QAbstractItemDelegate::EndEditHint ){
-    QString NewValue = reinterpret_cast<QLineEdit*>(editor)->text();
-    QModelIndexList indexes = ui->wavefrontList->selectionModel()->selectedIndexes();
-    if (indexes.length() == 1){
-        emit wftNameChanged(indexes[0].row(), NewValue);
+// this is troggered on renaming/editing end
+void surfaceAnalysisTools::ListWidgetEditEnd(QWidget* editor, QAbstractItemDelegate::EndEditHint ){
+    const QString NewValue = reinterpret_cast<QLineEdit*>(editor)->text();
+    QModelIndexList indexList = ui->wavefrontList->selectionModel()->selectedIndexes();
+    // because we don't know exactly which wft has been renamed in case of multiple selection
+    for (const QModelIndex &index : indexList) {
+        const int row = index.row();
+        if(NewValue == ui->wavefrontList->item(row)->text()){
+            emit wftNameChanged(index.row(), ui->wavefrontList->item(row)->text());
+            on_wavefrontList_clicked(index); //force complete redisplay to reload every name where they are printed
+            // we cannot break; the loop because there might be duplicate names (rare but can happen)
+        }
     }
-    //emit wftNameChanged(t.row(), item->text());
 }
 
 void surfaceAnalysisTools::on_pushButton_clicked()

--- a/surfaceanalysistools.cpp
+++ b/surfaceanalysistools.cpp
@@ -165,7 +165,7 @@ void surfaceAnalysisTools::on_wavefrontList_customContextMenuRequested(const QPo
     connect(deleteAction, &QAction::triggered, [this, item]() {
         on_deleteWave_clicked();
     });
-    deleteAction->setShortcuts(QKeySequence::Delete);
+    deleteAction->setShortcut(QKeySequence::Delete);
     contextMenu.addAction(deleteAction);
 
     // Create "Invert" action
@@ -180,6 +180,7 @@ void surfaceAnalysisTools::on_wavefrontList_customContextMenuRequested(const QPo
     connect(renameAction, &QAction::triggered, [this, item]() {
         ui->wavefrontList->editItem(item);
     });
+    renameAction->setShortcut(QKeySequence(Qt::Key_F2));
     contextMenu.addAction(renameAction);
 
     // Create "Rotate" action

--- a/surfaceanalysistools.cpp
+++ b/surfaceanalysistools.cpp
@@ -114,7 +114,11 @@ void surfaceAnalysisTools::currentNdxChanged(int ndx){
 
     QListWidgetItem *item = ui->wavefrontList->item(lastCurrentItem);
     if (item){
-        item->setIcon(style()->standardIcon(QStyle::SP_CustomBase));
+        QIcon blankIcon;
+        QPixmap pixmap(16, 16);
+        pixmap.fill(Qt::transparent);
+        blankIcon.addPixmap(pixmap);
+        item->setIcon(blankIcon); // use a transparent icon to align text
     }
     ui->wavefrontList->setCurrentRow(ndx,QItemSelectionModel::Current);
 

--- a/surfaceanalysistools.cpp
+++ b/surfaceanalysistools.cpp
@@ -161,6 +161,13 @@ void surfaceAnalysisTools::on_wavefrontList_customContextMenuRequested(const QPo
     });
     contextMenu.addAction(deleteAction);
 
+    // Create "Invert" action
+    QAction *invertAction = new QAction("Invert", this);
+    connect(invertAction, &QAction::triggered, [this, item]() {
+        on_InvertPB_pressed();
+    });
+    contextMenu.addAction(invertAction);
+
     // Create "Rename" action
     QAction *renameAction = new QAction("Rename", this);
     connect(renameAction, &QAction::triggered, [this, item]() {
@@ -168,7 +175,12 @@ void surfaceAnalysisTools::on_wavefrontList_customContextMenuRequested(const QPo
     });
     contextMenu.addAction(renameAction);
 
-    // TODO later add "invert" and "rotate"
+    // Create "Rotate" action
+    QAction *rotateAction = new QAction("Rotate", this);
+    connect(rotateAction, &QAction::triggered, [this, item]() {
+        on_transformsPB_clicked();
+    });
+    contextMenu.addAction(rotateAction);
 
     // Show the context menu at the cursor position
     contextMenu.exec(ui->wavefrontList->mapToGlobal(pos));

--- a/surfaceanalysistools.cpp
+++ b/surfaceanalysistools.cpp
@@ -288,7 +288,7 @@ void surfaceAnalysisTools::on_InvertPB_pressed()
     emit invert(SelectedWaveFronts());
 }
 
-// this is troggered on renaming/editing end
+// this is triggered on renaming/editing end
 void surfaceAnalysisTools::ListWidgetEditEnd(QWidget* editor, QAbstractItemDelegate::EndEditHint ){
     const QString NewValue = reinterpret_cast<QLineEdit*>(editor)->text();
     QModelIndexList indexList = ui->wavefrontList->selectionModel()->selectedIndexes();

--- a/surfaceanalysistools.cpp
+++ b/surfaceanalysistools.cpp
@@ -56,7 +56,7 @@ surfaceAnalysisTools::surfaceAnalysisTools(QWidget *parent) :
     connect(ui->wavefrontList->itemDelegate(), SIGNAL(closeEditor(QWidget*, QAbstractItemDelegate::EndEditHint)), this,
             SLOT(ListWidgetEditEnd(QWidget*, QAbstractItemDelegate::EndEditHint)));
     ui->wavefrontList->setContextMenuPolicy(Qt::CustomContextMenu);
-    QShortcut* delShortcut = new QShortcut(Qt::Key_Delete, this);
+    QShortcut* delShortcut = new QShortcut(QKeySequence::Delete, this);
     connect(delShortcut, &QShortcut::activated, this, &surfaceAnalysisTools::on_deleteWave_clicked);
 }
 
@@ -165,6 +165,7 @@ void surfaceAnalysisTools::on_wavefrontList_customContextMenuRequested(const QPo
     connect(deleteAction, &QAction::triggered, [this, item]() {
         on_deleteWave_clicked();
     });
+    deleteAction->setShortcuts(QKeySequence::Delete);
     contextMenu.addAction(deleteAction);
 
     // Create "Invert" action

--- a/surfaceanalysistools.cpp
+++ b/surfaceanalysistools.cpp
@@ -74,6 +74,7 @@ void surfaceAnalysisTools::addWaveFront(const QString &name){
 
     ui->wavefrontList->addItem(shorter);
     lastCurrentItem = ui->wavefrontList->count()-1;
+    ui->wavefrontList->item(lastCurrentItem)->setFlags(Qt::ItemIsEditable | Qt::ItemIsEnabled | Qt::ItemIsSelectable);
 
 }
 
@@ -94,10 +95,8 @@ void surfaceAnalysisTools::on_blurCB_clicked(bool checked)
 
 void surfaceAnalysisTools::on_wavefrontList_itemDoubleClicked(QListWidgetItem *item)
 {
-
     ui->wavefrontList->editItem(item);
     emit wavefrontDClicked(item->text());
-
 }
 
 void surfaceAnalysisTools::on_spinBox_valueChanged(int arg1)
@@ -130,9 +129,13 @@ void surfaceAnalysisTools::deleteWaveFront(int i){
 
 }
 
+// thiis is called when pressing enter on a wevefront selected with arrow key
+void surfaceAnalysisTools::on_wavefrontList_activated(const QModelIndex &index)
+{
+    on_wavefrontList_clicked(index);
+}
 void surfaceAnalysisTools::on_wavefrontList_clicked(const QModelIndex &index)
 {
-
     QListWidgetItem *item = ui->wavefrontList->item(lastCurrentItem);
     if (item)
         item->setForeground(Qt::gray);
@@ -150,6 +153,7 @@ void surfaceAnalysisTools::on_wavefrontList_clicked(const QModelIndex &index)
     emit waveFrontClicked(indexes.last().row());
     currentNdxChanged(index.row());
 }
+
 QList<int> surfaceAnalysisTools::SelectedWaveFronts(){
     QModelIndexList indexes = ui->wavefrontList->selectionModel()->selectedIndexes();
 
@@ -246,14 +250,13 @@ void surfaceAnalysisTools::on_InvertPB_pressed()
     emit invert(SelectedWaveFronts());
 }
 
+// this is "right click" on windows
 void surfaceAnalysisTools::on_wavefrontList_customContextMenuRequested(const QPoint &pos)
 {
-    QModelIndex t = ui->wavefrontList->indexAt(pos);
-    QListWidgetItem *item = ui->wavefrontList->item(t.row());
+    QListWidgetItem *item = ui->wavefrontList->itemAt(pos);
     if (item == 0)
         return;
-    item->setFlags(Qt::ItemIsEditable | Qt::ItemIsEnabled | Qt::ItemIsSelectable);
-    ui->wavefrontList->item(t.row())->setSelected(true);	// even a right click will select the item
+    item->setSelected(true);	// even a right click will select the item
     ui->wavefrontList->editItem(item);
 }
 

--- a/surfaceanalysistools.cpp
+++ b/surfaceanalysistools.cpp
@@ -21,6 +21,7 @@
 #include <QDebug>
 #include <QMenu>
 #include <QSettings>
+#include <QShortcut>
 #include <QtAlgorithms>
 #include <QLineEdit>
 #include "mirrordlg.h"
@@ -55,6 +56,8 @@ surfaceAnalysisTools::surfaceAnalysisTools(QWidget *parent) :
     connect(ui->wavefrontList->itemDelegate(), SIGNAL(closeEditor(QWidget*, QAbstractItemDelegate::EndEditHint)), this,
             SLOT(ListWidgetEditEnd(QWidget*, QAbstractItemDelegate::EndEditHint)));
     ui->wavefrontList->setContextMenuPolicy(Qt::CustomContextMenu);
+    QShortcut* dellShortcut = new QShortcut(Qt::Key_Delete, this);
+    connect(dellShortcut, &QShortcut::activated, this, &surfaceAnalysisTools::on_deleteWave_clicked);
 }
 
 void surfaceAnalysisTools::enableControls(bool flag){

--- a/surfaceanalysistools.cpp
+++ b/surfaceanalysistools.cpp
@@ -125,6 +125,9 @@ void surfaceAnalysisTools::currentNdxChanged(int ndx){
 }
 
 void surfaceAnalysisTools::deleteWaveFront(int i){
+    if(lastCurrentItem > i) {
+        lastCurrentItem--;
+    }
     QListWidgetItem* item = ui->wavefrontList->takeItem(i);
     delete item;
 }

--- a/surfaceanalysistools.cpp
+++ b/surfaceanalysistools.cpp
@@ -286,12 +286,16 @@ void surfaceAnalysisTools::on_InvertPB_pressed()
 void surfaceAnalysisTools::ListWidgetEditEnd(QWidget* editor, QAbstractItemDelegate::EndEditHint ){
     const QString NewValue = reinterpret_cast<QLineEdit*>(editor)->text();
     QModelIndexList indexList = ui->wavefrontList->selectionModel()->selectedIndexes();
-    // because we don't know exactly which wft has been renamed in case of multiple selection
+    // because we don't know exactly which wft has been renamed in case of multiple selection, we must update name for all
     for (const QModelIndex &index : indexList) {
         const int row = index.row();
+        // update name only for thoseactually matching new name (that have actually be renamed)
         if(NewValue == ui->wavefrontList->item(row)->text()){
             emit wftNameChanged(index.row(), ui->wavefrontList->item(row)->text());
-            on_wavefrontList_clicked(index); //force complete redisplay to reload every name where they are printed
+            //force complete redisplay to reload if rename was on currently displayed wft
+            if(index.row() == lastCurrentItem) {
+                on_wavefrontList_clicked(index);
+            }
             // we cannot break; the loop because there might be duplicate names (rare but can happen)
         }
     }

--- a/surfaceanalysistools.h
+++ b/surfaceanalysistools.h
@@ -77,13 +77,13 @@ public slots:
     void defocusControlChanged(double);
     void enableControls(bool);
 private slots:
-
     void on_wavefrontList_itemDoubleClicked(QListWidgetItem *item);
 
     void on_spinBox_valueChanged(int arg1);
 
     void on_spinBox_2_valueChanged(int arg1);
 
+    void on_wavefrontList_activated(const QModelIndex &index);
     void on_wavefrontList_clicked(const QModelIndex &index);
 
     void on_blurCB_clicked(bool checked);

--- a/surfaceanalysistools.h
+++ b/surfaceanalysistools.h
@@ -54,7 +54,6 @@ signals:
     void doxform(QList<int>);
     void surfaceSmoothGBValue(double);
     void surfaceSmoothGBEnabled(bool);
-    void wavefrontDClicked(const QString &);
     void waveFrontClicked(int ndx);
     void outsideMaskValue(int);
     void centerMaskValue(int);
@@ -77,14 +76,13 @@ public slots:
     void defocusControlChanged(double);
     void enableControls(bool);
 private slots:
-    void on_wavefrontList_itemDoubleClicked(QListWidgetItem *item);
-
     void on_spinBox_valueChanged(int arg1);
 
     void on_spinBox_2_valueChanged(int arg1);
 
     void on_wavefrontList_activated(const QModelIndex &index);
     void on_wavefrontList_clicked(const QModelIndex &index);
+    void on_wavefrontList_customContextMenuRequested(const QPoint &pos);
 
     void on_blurCB_clicked(bool checked);
 
@@ -98,9 +96,7 @@ private slots:
 
     void on_SelectNonePB_clicked();
 
-     void on_InvertPB_pressed();
-
-    void on_wavefrontList_customContextMenuRequested(const QPoint &pos);
+    void on_InvertPB_pressed();
 
     void ListWidgetEditEnd(QWidget *editor, QAbstractItemDelegate::EndEditHint);
 

--- a/surfaceanalysistools.ui
+++ b/surfaceanalysistools.ui
@@ -138,7 +138,7 @@
           </sizepolicy>
          </property>
          <property name="editTriggers">
-          <set>QAbstractItemView::DoubleClicked</set>
+          <set>QAbstractItemView::DoubleClicked|QAbstractItemView::EditKeyPressed</set>
          </property>
          <property name="alternatingRowColors">
           <bool>true</bool>

--- a/surfacemanager.cpp
+++ b/surfacemanager.cpp
@@ -508,7 +508,6 @@ SurfaceManager::SurfaceManager(QObject *parent, surfaceAnalysisTools *tools,
     connect(m_toolsEnableTimer, SIGNAL(timeout()), this, SLOT(enableTools()));
 
     connect(m_surfaceTools, SIGNAL(waveFrontClicked(int)), this, SLOT(waveFrontClickedSlot(int)));
-    connect(m_surfaceTools, SIGNAL(wavefrontDClicked(const QString &)), this, SLOT(wavefrontDClicked(const QString &)));
     connect(m_surfaceTools, SIGNAL(centerMaskValue(int)),this, SLOT(centerMaskValue(int)));
     connect(m_surfaceTools, SIGNAL(outsideMaskValue(int)),this, SLOT(outsideMaskValue(int)));
     connect(m_surfaceTools, SIGNAL(surfaceSmoothGBEnabled(bool)), this, SLOT(surfaceSmoothGBEnabled(bool)));
@@ -794,7 +793,7 @@ void SurfaceManager::deleteWaveFronts(QList<int> list){
 
 void SurfaceManager::wavefrontDClicked(const QString & name){
     for (int i = 0; i < m_wavefronts.size(); ++i){
-        if (m_wavefronts[i]->name.endsWith(name)){
+        if (m_wavefronts[i]->name.endsWith(name)){ //TODO JST 2023/09/11 this does not work on some name combinations. To be fixed
             m_currentNdx = i;
             sendSurface(m_wavefronts[i]);
             break;


### PR DESCRIPTION
fix #87 

- [x] press enter displays wft
- [x] F2 renames wft
- [x] ~~right click does not rename anymore~~ Do a real right click menu instead as per George recommandation
- [x] double click has no special effect anymore
- [x] greying out wft names is strange behavior
- [x] create a shortcut for delete wft (dell key)
- [x] any edit will trigger correct signal to reload the wft and have name displayed correctly everywhere
- [x] right click menu can rotate and invert
- [x] fix display bug on delete

I think I achieved something very nice.
Now the actually displayed wft has a small icon in front. I think this is what Dale wanted to achieve with gray/black foreground but it was not 100% working and not always displaying what it should on multi-selection.

Also fixed a bug where wft name could be wrong on metrics window
![image](https://github.com/githubdoe/DFTFringe/assets/4628382/2b59355f-8b47-4f30-9375-d3d449c88f60)

![image](https://github.com/githubdoe/DFTFringe/assets/4628382/7929d36a-ae17-440c-b494-45d42af8590d)
