### PR TITLE
fix little mistake in Dale's .pro introduced in #84

### DIFF
--- a/DFTFringe_Dale.pro
+++ b/DFTFringe_Dale.pro
@@ -140,7 +140,6 @@ SOURCES += main.cpp \
     psitiltoptions.cpp \
     contourrulerparams.cpp \
     zernikesmoothingdlg.cpp \
-    punwrap.cpp \ 
     SingleApplication/singleapplication.cpp \
     SingleApplication/singleapplication_p.cpp
 
@@ -412,6 +411,7 @@ VERSION = 6.2
 
 # Define the preprocessor macro to get the application version in our application.
 DEFINES += APP_VERSION=\\\"$$VERSION\\\"
+DEFINES += QAPPLICATION_CLASS=QApplication
 
 DISTFILES += \
     buildingDFTFringe64.txt \


### PR DESCRIPTION
Default `QAPPLICATION_CLASS` has changed in update of SingleApplication lib. I forgot to add this line in Dale's .pro
DEFINES += QAPPLICATION_CLASS=QApplication