### PR TITLE
Fixes issue #91.  This bug was bothering me for a few months.  

### DIFF
--- a/zernikedlg.h
+++ b/zernikedlg.h
@@ -27,7 +27,7 @@
 #include <vector>
 #include <QVector>
 
-#define Z_TERMS 48
+#define Z_TERMS 49
 
 namespace Ui {
 class zernikeDlg;

--- a/zernikeprocess.cpp
+++ b/zernikeprocess.cpp
@@ -858,7 +858,7 @@ void zernikeProcess::fillVoid(wavefront &wf){
                         zpolar.init(rho,theta);
                         double v = 0.;
 
-                        for (int z = 0; z < wf.InputZerns.size(); ++z){
+                        for (size_t z = 0; z < wf.InputZerns.size(); ++z){
                             v += wf.InputZerns[z] * zpolar.zernike(z,rho, theta);
                         }
                         wf.data.at<double>(y,x) = v;
@@ -910,7 +910,7 @@ void zernikeProcess::fillVoid(wavefront &wf){
                     zpolar.init(rho,theta);
                     double v = 0.;
 
-                    for (int z = 0; z < wf.InputZerns.size(); ++z){
+                    for (size_t z = 0; z < wf.InputZerns.size(); ++z){
                         v += wf.InputZerns[z] * zpolar.zernike(z,rho, theta);
                     }
                     wf.data.at<double>(y,x) = v;

--- a/zernikeprocess.cpp
+++ b/zernikeprocess.cpp
@@ -826,10 +826,6 @@ void zernikeProcess::fillVoid(wavefront &wf){
         int endx = x;
         int starty = y;
         int endy = y;
-        qDebug() << "regions to fill: " << wf.regions.size();
-        for (int z = 0; z < m_norms.size(); ++z){
-            qDebug() << "zern "<< z << " " << wf.InputZerns[z];
-        }
         for (int n = 0; n < wf.regions.size(); ++n){
 
             for (std::size_t i = 0; i < wf.regions[n].size(); ++i){
@@ -862,6 +858,7 @@ void zernikeProcess::fillVoid(wavefront &wf){
                         double v = 0.;
 
                         for (int z = 0; z < m_norms.size(); ++z){
+                            if (z >= Z_TERMS) break; // fixes issue #91
                             v += wf.InputZerns[z] * zpolar.zernike(z,rho, theta);
                         }
                         wf.data.at<double>(y,x) = v;
@@ -914,6 +911,7 @@ void zernikeProcess::fillVoid(wavefront &wf){
                     double v = 0.;
 
                     for (int z = 0; z < m_norms.size(); ++z){
+                        if (z >= Z_TERMS) break;
                         v += wf.InputZerns[z] * zpolar.zernike(z,rho, theta);
                     }
                     wf.data.at<double>(y,x) = v;

--- a/zernikeprocess.cpp
+++ b/zernikeprocess.cpp
@@ -826,6 +826,7 @@ void zernikeProcess::fillVoid(wavefront &wf){
         int endx = x;
         int starty = y;
         int endy = y;
+
         for (int n = 0; n < wf.regions.size(); ++n){
 
             for (std::size_t i = 0; i < wf.regions[n].size(); ++i){
@@ -857,8 +858,7 @@ void zernikeProcess::fillVoid(wavefront &wf){
                         zpolar.init(rho,theta);
                         double v = 0.;
 
-                        for (int z = 0; z < m_norms.size(); ++z){
-                            if (z >= Z_TERMS) break; // fixes issue #91
+                        for (int z = 0; z < wf.InputZerns.size(); ++z){
                             v += wf.InputZerns[z] * zpolar.zernike(z,rho, theta);
                         }
                         wf.data.at<double>(y,x) = v;
@@ -910,8 +910,7 @@ void zernikeProcess::fillVoid(wavefront &wf){
                     zpolar.init(rho,theta);
                     double v = 0.;
 
-                    for (int z = 0; z < m_norms.size(); ++z){
-                        if (z >= Z_TERMS) break;
+                    for (int z = 0; z < wf.InputZerns.size(); ++z){
                         v += wf.InputZerns[z] * zpolar.zernike(z,rho, theta);
                     }
                     wf.data.at<double>(y,x) = v;


### PR DESCRIPTION
The final zernike term (49th term aka #48 aka "5th spherical") was sometimes a huge value.

I don't know if I'm hiding some other bug where the last entry in the zernike terms array gets overwritten or if the last value is never calculated in the first place.  But if it's some other bug, then Dale seems to have also hidden the bug by using 48 terms instead of 49 terms in the Zernike table on the left side of DFTF.

Z_TERMS is 48 and not 49 (49 would be 7*7 which would be more typical qty of terms).  Z_TERMS seems to limit how many
terms are displayed in the left side of the gui.

Anyway, this commit fixes the problem and will work just fine even if M_norms.size() changes some day.

Please see issue #91 for screenshot and more details.

I removed the logging as it is no longer needed now that I understand the bug.