### PR TITLE
Fixes issue #97

### DIFF
--- a/igramarea.cpp
+++ b/igramarea.cpp
@@ -2437,6 +2437,8 @@ void IgramArea::writeOutlines(QString fileName){
     saveFile.write(jsondoc.toJson());
     saveFile.close();
 
+    saveRegions(); // save regions to registry also
+
 }
 
 void IgramArea::saveOutlines(){


### PR DESCRIPTION
When I created the new writeRegions() function that writes to the OLN file in the new format, I didn't include the saveRegions() command (which writes the regions to the registry).  Now fixed.

Saving the mirror outline is done in crop().  Maybe these things should all be in one place?  Maybe writeRegions() should only be called from crop.  Not sure.  I'm just leaving it how it was as it works just fine now.