### PR TITLE
Fixes issue #112 (smoothing wavefront crashes if obstruction)

### DIFF
--- a/RevisionHistory.html
+++ b/RevisionHistory.html
@@ -369,7 +369,7 @@ Displays error of pixel under contour plot cursor and move the profie angle to m
 </ul></ul>
 </ul>
 
-<ul><li>Version 7.1.0</li>
+<ul><li>Version 7.1.1</li>
 <ul>
 <li>Added logging to assist with debugging, particularly if there is a crash. To view log file go to exe folder then DFTFringeLogs/log.txt</li>
 <li>Updated project dependencies</li>
@@ -387,7 +387,8 @@ Displays error of pixel under contour plot cursor and move the profie angle to m
 <li>Fixed issue where Foucault view display "TextLabel" instead of number</li>
 <li>Fixed regression introduced in 7.0.0 not displaying effects of central obstruction in most displays</li>
 <li>Removed unused interpolation drop down from rotate wavefront dialog</li>
-<li>Linux is not sensitive to jpg or other extension case anymore for selecting files</li>
+<li>Linux is not case sensitive to jpg (or other extension) anymore for selecting files</li>
 <li>Fixed regression introduced in 7.0.0 where regions might not be updated correctly when processing several igram</li>
+<li>Fixed crash if you smooth a wavefront that has an inner outline (perforated mirror). Bug existed staring ver 6.3.1.</li>
 </ul></ul>
 </ul>

--- a/zernikeprocess.cpp
+++ b/zernikeprocess.cpp
@@ -1410,7 +1410,7 @@ void zernikeProcess::initGrid(int width, double radius, double cx, double cy, in
         m_obsPercent = obsPercent;
         m_rhoTheta = rhotheta(width, radius, cx, cy);
 
-        if (obsPercent <= 0.) {
+        if (obsPercent < 0.) { // was "<=" but this can cause a crash see github issue #112
             m_zerns = zpmC(m_rhoTheta.row(0), m_rhoTheta.row(1), maxOrder);
 //            for (int i = 0; i < m_zerns.n_rows; ++i){
 //                if (m_row[i] == 300){

--- a/zernikeprocess.cpp
+++ b/zernikeprocess.cpp
@@ -1410,7 +1410,7 @@ void zernikeProcess::initGrid(int width, double radius, double cx, double cy, in
         m_obsPercent = obsPercent;
         m_rhoTheta = rhotheta(width, radius, cx, cy);
 
-        if (obsPercent < 0.) { // was "<=" but this can cause a crash see github issue #112
+        if (obsPercent >= 0.) { // was "<=" but this can cause a crash see github issue #112
             m_zerns = zpmC(m_rhoTheta.row(0), m_rhoTheta.row(1), maxOrder);
 //            for (int i = 0; i < m_zerns.n_rows; ++i){
 //                if (m_row[i] == 300){


### PR DESCRIPTION
Disabled zapmC() which crashes.  It doesn't seem to crash when I build it in qt creator but the version built by github definitely consistently crashes.  Don't know why but probably some according to Dale, the code might have known bugs.