### PR TITLE
Fixes issue #115 - issues with "edge mask" aka aperture reduction

### DIFF
--- a/dftarea.cpp
+++ b/dftarea.cpp
@@ -252,6 +252,8 @@ cv::Mat DFTArea::grayComplexMatfromImage(QImage &img){
 
     double pixelsPermm =(igramArea->m_outside.m_radius/(md.diameter/2.));
     double reduction = md.aperatureReduction * pixelsPermm;
+    if (md.m_aperatureReductionEnabled == false)
+        reduction = 0;
 
     double rad = igramArea->m_outside.m_radius - reduction;
 

--- a/mirrordlg.cpp
+++ b/mirrordlg.cpp
@@ -600,6 +600,8 @@ void mirrorDlg::on_buttonBox_helpRequested()
 void mirrorDlg::setclearAp(){
 
     m_clearAperature = (diameter - aperatureReduction * 2) ;
+    if (m_aperatureReductionEnabled == false)
+        m_clearAperature = diameter;
     ui->ClearAp->setText(QString("%1 ").arg(m_clearAperature * ((mm) ? 1: 1./25.4), 6, 'f', 2));
 }
 
@@ -625,13 +627,6 @@ void mirrorDlg::on_ReducApp_clicked(bool checked)
 }
 
 
-void mirrorDlg::changeEdgeMaskvalues(double val){
-    m_aperatureReductionEnabled = true;
-    ui->ReducApp->setChecked(true);
-    ui->reduceValue->setValue(val);
-    ui->reduceValue->setEnabled(true);
-
-}
 void mirrorDlg::on_reduceValue_valueChanged(double arg1)
 {
     aperatureReduction = ((mm) ? 1: 25.4) * arg1;

--- a/mirrordlg.h
+++ b/mirrordlg.h
@@ -66,7 +66,6 @@ public:
     outlineShape m_outlineShape;
     bool isEllipse();
     void setMinorAxis(double val);
-    void changeEdgeMaskvalues(double val);
     bool m_aperatureReductionEnabled;
 private slots:
     void on_ReadBtn_clicked();


### PR DESCRIPTION
When reading old OLN files, ignore edge mask
When writing OLN files don't save edge mask
Fixed 2 locations where edge mask needs to be set to zero when checkbox is not checked in mirror dialog Fixed bug where edge mask is checked if not found in OLN file!