### PR TITLE
update armadillo to v12.6.7

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -8,7 +8,7 @@ on:
   workflow_call:
 
 env:
-  armadillo_version: 12.6.1
+  armadillo_version: 12.6.7
   QWT_version: 6.1.6
   openCV_version: 4.6.0
   QT_version: 5.15.2
@@ -160,7 +160,6 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-            build_armadillo\libarmadillo.dll
             build_armadillo\tmp\include
           key: ${{ runner.os }}-armadillo-${{env.armadillo_version}}
 
@@ -287,7 +286,6 @@ jobs:
         id: cache-armadillo
         with:
           path: |
-            build_armadillo\libarmadillo.dll
             build_armadillo\tmp\include
           key: ${{ runner.os }}-armadillo-${{env.armadillo_version}}
           fail-on-cache-miss: true

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -150,55 +150,7 @@ jobs:
         if: steps.cache-QWT.outputs.cache-hit != 'true'
         run: cd qwt-${{env.QWT_version}} ; mingw32-make -j4
 
-  build-armadillo:
-    runs-on: windows-latest
-    needs: cache-mingw-from-QT
-    steps:
-      # this will restore/cache everything depending on cache hit/miss
-      - name: Cache armadillo build
-        id: cache-armadillo
-        uses: actions/cache@v4
-        with:
-          path: |
-            build_armadillo\tmp\include
-          key: ${{ runner.os }}-armadillo-${{env.armadillo_version}}
-
-      # all what follows is only run on cache miss
-
-      # restore cached minGW
-      - uses: actions/cache/restore@v4
-        if: steps.cache-armadillo.outputs.cache-hit != 'true'
-        id: cache-minGW
-        with:
-          path: Tools
-          key: ${{ runner.os }}-mingw${{env.mingw_version}}_64
-          fail-on-cache-miss: true
-      - name: add minGW to path
-        if: steps.cache-armadillo.outputs.cache-hit != 'true'
-        shell: bash
-        run: echo "${{github.workspace}}\Tools\mingw${{env.mingw_version}}_64\bin" >> $GITHUB_PATH
-      - name: install wget
-        if: steps.cache-armadillo.outputs.cache-hit != 'true'
-        run: choco install -y wget
-      - name: download armadillo
-        if: steps.cache-armadillo.outputs.cache-hit != 'true'
-        # I specified the mirror because one of the random mirrors did not work during my tests
-        run: wget -O armadillo-${{env.armadillo_version}}.tar.xz http://sourceforge.net/projects/arma/files/armadillo-${{env.armadillo_version}}.tar.xz/download?use_mirror=versaweb
-      # Extract in two step. First step write to stdo and second step read from stdi.
-      # This avoids intermediate file creation
-      # It must run in CMD because powershell corrupts pipes
-      - name: extract archive
-        if: steps.cache-armadillo.outputs.cache-hit != 'true'
-        run: 7z x -so armadillo-${{env.armadillo_version}}.tar.xz | 7z x -si -ttar
-        shell: cmd
-      - name: cmake generate
-        if: steps.cache-armadillo.outputs.cache-hit != 'true'
-        run: cmake -G "MinGW Makefiles" -S armadillo-${{env.armadillo_version}} -B build_armadillo
-      - name: cmake build
-        if: steps.cache-armadillo.outputs.cache-hit != 'true'
-        run: cmake --build ./build_armadillo -j4
-
-  build-lapack:
+  build-lapack-armadillo:
     runs-on: windows-latest
     needs: cache-mingw-from-QT
     steps:
@@ -208,9 +160,10 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-            build_lapack\lib\liblapack.a
-            build_lapack\lib\libblas.a
-          key: ${{ runner.os }}-lapack-${{env.lapack_version}}
+            build_lapack\bin\liblapack.dll
+            build_lapack\bin\libblas.dll
+            build_armadillo\tmp\include
+          key: ${{ runner.os }}-lapack-${{env.lapack_version}}-armadillo-${{env.armadillo_version}}
 
       # all what follows is only run on cache miss
 
@@ -232,18 +185,39 @@ jobs:
           repository: 'Reference-LAPACK/lapack'
           ref: 'v${{env.lapack_version}}'
           path: './lapack'
-      # remove test compiler because https://github.com/Reference-LAPACK/lapack/issues/305 not needed to create DLL
+      # See https://github.com/Reference-LAPACK/lapack/issues/305 : CMAKE_SHARED_LINKER_FLAGS is fixing a build issue
       - name: cmake generate
         if: steps.cache-lapack.outputs.cache-hit != 'true'
-        run: cmake -G "MinGW Makefiles" -S lapack -B build_lapack -D TEST_FORTRAN_COMPILER=OFF
+        run: cmake -G "MinGW Makefiles" -S lapack -B build_lapack -D BUILD_SHARED_LIBS=ON -D CMAKE_SHARED_LINKER_FLAGS="-Wl,--allow-multiple-definition"
       - name: cmake build
         if: steps.cache-lapack.outputs.cache-hit != 'true'
         run: cmake --build ./build_lapack -j4
-
+      # now that Lapack is built, do the Armadillo build
+      - name: install wget
+        if: steps.cache-lapack.outputs.cache-hit != 'true'
+        run: choco install -y wget
+      - name: download armadillo
+        if: steps.cache-lapack.outputs.cache-hit != 'true'
+        # I specified the mirror because one of the random mirrors did not work during my tests
+        run: wget -O armadillo-${{env.armadillo_version}}.tar.xz http://sourceforge.net/projects/arma/files/armadillo-${{env.armadillo_version}}.tar.xz/download?use_mirror=versaweb
+      # Extract in two step. First step write to stdo and second step read from stdi.
+      # This avoids intermediate file creation
+      # It must run in CMD because powershell corrupts pipes
+      - name: extract archive
+        if: steps.cache-lapack.outputs.cache-hit != 'true'
+        run: 7z x -so armadillo-${{env.armadillo_version}}.tar.xz | 7z x -si -ttar
+        shell: cmd
+      # Armadillo relies on Lapack, it's important it knowns where it is during genration to be configured correctly
+      - name: cmake generate
+        if: steps.cache-lapack.outputs.cache-hit != 'true'
+        run: cmake -D CMAKE_PREFIX_PATH=${{github.workspace}}/build_lapack -G "MinGW Makefiles" -S armadillo-${{env.armadillo_version}} -B build_armadillo
+      - name: cmake build
+        if: steps.cache-lapack.outputs.cache-hit != 'true'
+        run: cmake --build ./build_armadillo -j4
 
   build-DFTFringe:
     runs-on: windows-latest
-    needs: [cache-mingw-from-QT, build-lapack, build-armadillo, build-QWT, build-openCV-with-QT]
+    needs: [cache-mingw-from-QT, build-lapack-armadillo, build-QWT, build-openCV-with-QT]
     steps:
 
       # because problem matcher will not work when chechout in a subfolder,
@@ -272,22 +246,15 @@ jobs:
       - name: add minGW to path
         shell: bash
         run: echo "${{github.workspace}}\Tools\mingw${{env.mingw_version}}_64\bin" >> $GITHUB_PATH
-      # restore cached lapack
+      # restore cached lapack and armadillo
       - uses: actions/cache/restore@v4
         id: cache-lapack
         with:
           path: |
-            build_lapack\lib\liblapack.a
-            build_lapack\lib\libblas.a
-          key: ${{ runner.os }}-lapack-${{env.lapack_version}}
-          fail-on-cache-miss: true
-      # restore cached armadillo
-      - uses: actions/cache/restore@v4
-        id: cache-armadillo
-        with:
-          path: |
+            build_lapack\bin\liblapack.dll
+            build_lapack\bin\libblas.dll
             build_armadillo\tmp\include
-          key: ${{ runner.os }}-armadillo-${{env.armadillo_version}}
+          key: ${{ runner.os }}-lapack-${{env.lapack_version}}-armadillo-${{env.armadillo_version}}
           fail-on-cache-miss: true
       # restore cached QWT
       - uses: actions/cache/restore@v4
@@ -362,6 +329,8 @@ jobs:
           Copy-Item ".\DFTFringe\Release\DFTFringe.exe.debug" -Destination ".\"
           mkdir ".\DFTFringe\DFTFringeInstaller\packages\com.githubdoe.DFTFringe\data"
           Copy-Item ".\DFTFringe\Release\DFTFringe.exe" -Destination ".\DFTFringe\DFTFringeInstaller\packages\com.githubdoe.DFTFringe\data"
+          Copy-Item ".\build_lapack\bin\liblapack.dll" -Destination ".\DFTFringe\DFTFringeInstaller\packages\com.githubdoe.DFTFringe\data"
+          Copy-Item ".\build_lapack\bin\libblas.dll" -Destination ".\DFTFringe\DFTFringeInstaller\packages\com.githubdoe.DFTFringe\data"
           Copy-Item ".\build_openCV\install\x64\mingw\bin\libopencv_calib3d460.dll" -Destination ".\DFTFringe\DFTFringeInstaller\packages\com.githubdoe.DFTFringe\data"
           Copy-Item ".\build_openCV\install\x64\mingw\bin\libopencv_core460.dll" -Destination ".\DFTFringe\DFTFringeInstaller\packages\com.githubdoe.DFTFringe\data"
           Copy-Item ".\build_openCV\install\x64\mingw\bin\libopencv_features2d460.dll" -Destination ".\DFTFringe\DFTFringeInstaller\packages\com.githubdoe.DFTFringe\data"
@@ -376,7 +345,6 @@ jobs:
           Copy-Item ".\DFTFringe\res\surface_LeY_icon.ico" -Destination ".\DFTFringe\DFTFringeInstaller\packages\com.githubdoe.DFTFringe\data\res"
           Copy-Item ".\DFTFringe\res\help" -Destination ".\DFTFringe\DFTFringeInstaller\packages\com.githubdoe.DFTFringe\data\res\help" -Recurse
           Copy-Item ".\DFTFringe\RevisionHistory.html" -Destination ".\DFTFringe\DFTFringeInstaller\packages\com.githubdoe.DFTFringe\data"
-
       - name: automatically add QT dependencies with windeployqt
         run: .\${{env.QT_version}}\mingw81_64\bin\windeployqt.exe DFTFringe\DFTFringeInstaller\packages\com.githubdoe.DFTFringe\data\DFTFringe.exe
 

--- a/DFTFringe.pro
+++ b/DFTFringe.pro
@@ -47,7 +47,6 @@ win32 {
     INCLUDEPATH += ..\build_armadillo\tmp\include
     INCLUDEPATH += ..\build_openCV\install\include
 
-    LIBS += ..\build_armadillo\libarmadillo.dll
     LIBS += ..\build_lapack\lib\libblas.a
     LIBS += ..\build_lapack\lib\liblapack.a
     LIBS += ..\build_openCV\install\x64\mingw\bin\libopencv_calib3d460.dll

--- a/DFTFringe.pro
+++ b/DFTFringe.pro
@@ -47,14 +47,17 @@ win32 {
     INCLUDEPATH += ..\build_armadillo\tmp\include
     INCLUDEPATH += ..\build_openCV\install\include
 
-    LIBS += ..\build_lapack\lib\libblas.a
-    LIBS += ..\build_lapack\lib\liblapack.a
+    LIBS += ..\build_lapack\bin\libblas.dll
+    LIBS += ..\build_lapack\bin\liblapack.dll
     LIBS += ..\build_openCV\install\x64\mingw\bin\libopencv_calib3d460.dll
     LIBS += ..\build_openCV\install\x64\mingw\bin\libopencv_core460.dll
     LIBS += ..\build_openCV\install\x64\mingw\bin\libopencv_features2d460.dll
     LIBS += ..\build_openCV\install\x64\mingw\bin\libopencv_highgui460.dll
     LIBS += ..\build_openCV\install\x64\mingw\bin\libopencv_imgcodecs460.dll
     LIBS += ..\build_openCV\install\x64\mingw\bin\libopencv_imgproc460.dll
+
+    # This is for armadillo to not use wrapper. See https://gitlab.com/conradsnicta/armadillo-code#6-linux-and-macos-compiling-and-linking
+    DEFINES += ARMA_DONT_USE_WRAPPER
 }
 
 # LINUX ############


### PR DESCRIPTION
- Fixed Lapack build to generate Lapack and Blas DLLs instead static libs. See https://github.com/Reference-LAPACK/lapack/issues/305 where I added a comment for clean fix.
- Groupped Lapack and Armadillo build so that Armadillo is configured correctly and makes use of Lapack+Blas
- Add define of ARMA_DONT_USE_WRAPPER to fix linking process when using Armadillo
- Update Armadillo version to 12.6.7

Closes #129