### PR TITLE
Fixes a crash for when you switch from annulus to regular and back again

### DIFF
--- a/zernikeprocess.cpp
+++ b/zernikeprocess.cpp
@@ -766,6 +766,8 @@ cv::Mat zernikeProcess::null_unwrapped(wavefront&wf, std::vector<double> zerns, 
         // annular wave fronts already have this made elsewhere.
         if (!md->m_useAnnular){
             m_rhoTheta = rhotheta(nx ,wf.m_outside.m_radius, midx,midy, &wf);
+            if (m_lastusedAnnulus)
+                m_needsInit=true;
         }
         // now iterate over those points
         for (unsigned int i = 0; i < m_row.size(); ++i){


### PR DESCRIPTION
Fixes #144 

I almost made it set m_lastusedAnnulus to false but that would also be bed as initgrid still needs to recalculate zerns if called while mirror is non-annulus.

This should fix the problem.  I mean it passes my test.  If approved I will create a release and do more testing of annuluar and normal igrams.