### PR TITLE
Fix Issue147 - problems with save/load mirror configuration json file

### DIFF
--- a/mirrordlg.cpp
+++ b/mirrordlg.cpp
@@ -277,8 +277,7 @@ void mirrorDlg::loadFile(QString & fileName){
 
         ui->name->setText(QJsonValue(loadDoc["name"]).toString());
         ui->unitsCB->setChecked(true);
-        mm=true;// don't understand why this isn't set in the above line of code, but it isn't
-                // or maybe it gets set after this function returns
+        mm=true;  // setChecked() does not call on_unitsCB_clicked()
 
         // set diameter early - before setting roc and annulus percentage
         QJsonObject mirror = loadDoc["mirror"].toObject();

--- a/mirrordlg.cpp
+++ b/mirrordlg.cpp
@@ -277,10 +277,18 @@ void mirrorDlg::loadFile(QString & fileName){
 
         ui->name->setText(QJsonValue(loadDoc["name"]).toString());
         ui->unitsCB->setChecked(true);
-        ui->nullCB->setChecked( QJsonValue(loadDoc["useNull"]).toBool());
+        mm=true;// don't understand why this isn't set in the above line of code, but it isn't
+                // or maybe it gets set after this function returns
 
+        // set diameter early - before setting roc and annulus percentage
         QJsonObject mirror = loadDoc["mirror"].toObject();
         diameter = QJsonValue(mirror["diameter"]).toDouble();
+        ui->diameter->blockSignals(true);
+        ui->diameter->setText(QString("%1").arg(diameter, 6, 'f', 2));
+        ui->diameter->blockSignals(false);
+
+        ui->nullCB->setChecked( QJsonValue(loadDoc["useNull"]).toBool());
+
         obs = QJsonValue(mirror["obs diameter"]).toDouble();
         roc = QJsonValue(mirror["roc"]).toDouble();
         cc = QJsonValue(mirror["desired conic"]).toDouble();
@@ -301,6 +309,7 @@ void mirrorDlg::loadFile(QString & fileName){
         m_annularObsPercent = QJsonValue(Annulus["obs percentage"]).toDouble() * 100.;
         ui->useAnnulus->setChecked(m_useAnnular);
         ui->annulusPercent->setValue(m_annularObsPercent);
+        on_annulusPercent_valueChanged(m_annularObsPercent);
         enableAnnular(m_useAnnular);
 
         ui->fringeSpacingEdit->blockSignals(true);
@@ -310,9 +319,6 @@ void mirrorDlg::loadFile(QString & fileName){
         ui->obs->setText(QString().number(obs));
 
 
-        ui->diameter->blockSignals(true);
-        ui->diameter->setText(QString("%1").arg(diameter, 6, 'f', 2));
-        ui->diameter->blockSignals(false);
         ui->roc->blockSignals(true);
         ui->roc->setText(QString("%1").arg(roc, 6, 'f', 2));
         ui->roc->blockSignals(false);

--- a/mirrordlg.ui
+++ b/mirrordlg.ui
@@ -408,7 +408,7 @@ Wave Length nm</string>
            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Hole diameter.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
           </property>
           <property name="maximum">
-           <double>1000.000000000000000</double>
+           <double>10000.000000000000000</double>
           </property>
          </widget>
         </item>


### PR DESCRIPTION
One of the bugs had to do with a maximum value of 1000 for the annulus diameter.  I raised that to 10000 (10 meter mirrors max for hole in mirror) Another was that as you switched between inches and mm the annulus diameter value kept growing.