### PR TITLE
Fixes Issue153 - defocus adjustment crashes

### DIFF
--- a/mirrordlg.cpp
+++ b/mirrordlg.cpp
@@ -277,8 +277,7 @@ void mirrorDlg::loadFile(QString & fileName){
 
         ui->name->setText(QJsonValue(loadDoc["name"]).toString());
         ui->unitsCB->setChecked(true);
-        mm=true;// don't understand why this isn't set in the above line of code, but it isn't
-                // or maybe it gets set after this function returns
+        mm=true;  // setChecked() does not call on_unitsCB_clicked()
 
         // set diameter early - before setting roc and annulus percentage
         QJsonObject mirror = loadDoc["mirror"].toObject();

--- a/mirrordlg.cpp
+++ b/mirrordlg.cpp
@@ -277,10 +277,18 @@ void mirrorDlg::loadFile(QString & fileName){
 
         ui->name->setText(QJsonValue(loadDoc["name"]).toString());
         ui->unitsCB->setChecked(true);
-        ui->nullCB->setChecked( QJsonValue(loadDoc["useNull"]).toBool());
+        mm=true;// don't understand why this isn't set in the above line of code, but it isn't
+                // or maybe it gets set after this function returns
 
+        // set diameter early - before setting roc and annulus percentage
         QJsonObject mirror = loadDoc["mirror"].toObject();
         diameter = QJsonValue(mirror["diameter"]).toDouble();
+        ui->diameter->blockSignals(true);
+        ui->diameter->setText(QString("%1").arg(diameter, 6, 'f', 2));
+        ui->diameter->blockSignals(false);
+
+        ui->nullCB->setChecked( QJsonValue(loadDoc["useNull"]).toBool());
+
         obs = QJsonValue(mirror["obs diameter"]).toDouble();
         roc = QJsonValue(mirror["roc"]).toDouble();
         cc = QJsonValue(mirror["desired conic"]).toDouble();
@@ -301,6 +309,7 @@ void mirrorDlg::loadFile(QString & fileName){
         m_annularObsPercent = QJsonValue(Annulus["obs percentage"]).toDouble() * 100.;
         ui->useAnnulus->setChecked(m_useAnnular);
         ui->annulusPercent->setValue(m_annularObsPercent);
+        on_annulusPercent_valueChanged(m_annularObsPercent);
         enableAnnular(m_useAnnular);
 
         ui->fringeSpacingEdit->blockSignals(true);
@@ -310,9 +319,6 @@ void mirrorDlg::loadFile(QString & fileName){
         ui->obs->setText(QString().number(obs));
 
 
-        ui->diameter->blockSignals(true);
-        ui->diameter->setText(QString("%1").arg(diameter, 6, 'f', 2));
-        ui->diameter->blockSignals(false);
         ui->roc->blockSignals(true);
         ui->roc->setText(QString("%1").arg(roc, 6, 'f', 2));
         ui->roc->blockSignals(false);

--- a/mirrordlg.ui
+++ b/mirrordlg.ui
@@ -408,7 +408,7 @@ Wave Length nm</string>
            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Hole diameter.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
           </property>
           <property name="maximum">
-           <double>1000.000000000000000</double>
+           <double>10000.000000000000000</double>
           </property>
          </widget>
         </item>

--- a/surfacemanager.cpp
+++ b/surfacemanager.cpp
@@ -870,6 +870,8 @@ void SurfaceManager::defocusSetup(){
 }
 
 void SurfaceManager::defocusChanged(){
+    zernikeProcess &zp = *zernikeProcess::get_Instance();
+    zp.m_bDontProcessEvents=true;
 
     double val = m_surfaceTools->m_defocus;
     //if (!m_surfaceTools->m_useDefocus)
@@ -884,6 +886,7 @@ void SurfaceManager::defocusChanged(){
     m_ignoreInverse = old_ignore;
     m_profilePlot->setDefocusValue(val);
     m_waveFrontTimer->start(2000);
+    zp.m_bDontProcessEvents=false;
 
 }
 
@@ -1432,9 +1435,9 @@ void SurfaceManager::loadComplete(){
 // Update all surfaces since some control has changed.  Skip current surface it has already been done
 void SurfaceManager::backGroundUpdate(){
 
+    zernikeProcess &zp = *zernikeProcess::get_Instance();
     m_waveFrontTimer->stop();
     workProgress = 0;
-
     m_surfaceTools->setEnabled(false);
     QList<int> doThese =  m_surfaceTools->SelectedWaveFronts();
     workToDo = doThese.size();
@@ -1445,7 +1448,9 @@ void SurfaceManager::backGroundUpdate(){
         m_wavefronts[i]->wasSmoothed = false;
         makeMask(i);
         try {
+            zp.m_bDontProcessEvents=true;
             generateSurfacefromWavefront(i);
+            zp.m_bDontProcessEvents=false;
         }
         catch (int i) {
             break;

--- a/zernikeprocess.cpp
+++ b/zernikeprocess.cpp
@@ -598,7 +598,8 @@ zernikeProcess *zernikeProcess::get_Instance(){
 
 zernikeProcess::zernikeProcess(QObject *parent) :
     QObject(parent),m_gridRowSize(200), m_maxOrder(0),
-    m_needsInit(true),m_lastusedAnnulus(false),m_dirty_zerns(true)
+    m_needsInit(true),m_lastusedAnnulus(false),m_dirty_zerns(true),
+    m_bDontProcessEvents(false)
 {
     md = mirrorDlg::get_Instance();;
     QSettings set;
@@ -1276,7 +1277,8 @@ arma::mat zernikeProcess::rhotheta( int width, double radius, double cx, double 
     for (int y = 0; y < rows; ++y){
         double uy = (y -cy)/radius;
 
-        QApplication::processEvents();
+        if (!m_bDontProcessEvents)
+            QApplication::processEvents();
         for (int x = 0; x< rows; ++x){
 
             double ux = (x -cx)/radius;

--- a/zernikeprocess.h
+++ b/zernikeprocess.h
@@ -123,6 +123,8 @@ public:
     cv::Mat Z;
     cv::Mat inputZ;
     bool m_dirty_zerns;
+    bool m_bDontProcessEvents;
+
     mirrorDlg *md;
     MainWindow *mw;
     arma::mat m_zerns;


### PR DESCRIPTION
fixes issue #153 

This fix works great.  I had to disable a line of code and originally I was going to comment it out but decided to only disable the line for defocus (for now).

I think the line of code was meant to allow progress bars (a guess) but there are no progress bars visible at the time of this code running so I don't think it hurts anything.

I tested the hell out of this.  At first I got crashes after the 2 second "background" timer so I added the flag there as well.

@atsju or @githubdoe please review and approve