### PR TITLE
fixes issue #132 (saving wavefront on network drive is slow)

### DIFF
--- a/surfacemanager.cpp
+++ b/surfacemanager.cpp
@@ -918,9 +918,9 @@ void SurfaceManager::writeWavefront(QString fname, wavefront *wf, bool saveNulle
         for (int row = wf->data.rows - 1; row >=0; --row){
             for (int col = 0; col < wf->data.cols ; ++col){
                 if (saveNulled)
-                    file << wf->workData(row,col) << std::endl;
+                    file << wf->workData(row,col) << '\n';
                 else {
-                    file << wf->data(row,col) << std::endl;
+                    file << wf->data(row,col) << '\n';
 
                 }
             }


### PR DESCRIPTION
It turns out std::endl is also a command to flush out buffers!  Didn't know that.

A 300X300 wavefront was taking 51 seconds to save on my network drive.  After my simple change (check it out!  Such a simple change!) it takes < 1 second.  Not sure how long as it's too quick to measure very well.

I did a binary diff on the wavefront files created old way versus new way and they are identical.

I don't know how this affects unix wavefront files - I believe currently on the PC it stores CRLF in the wavefront file but in linux, only LF.  I don't think my change will affect this behavior.