### PR TITLE
Mirror config bug

### DIFF
--- a/RevisionHistory.html
+++ b/RevisionHistory.html
@@ -409,7 +409,7 @@ Displays error of pixel under contour plot cursor and move the profie angle to m
 </ul>
 </ul>
 
-<ul><li>Version 7.2.2</li>
+<ul><li>Version 7.2.3</li>
 <ul>
 <li>Improved DLL dependencies behavior for developers</li>
 <li>Fixed a bug in mirror config when switching between inch and millimeter</li>

--- a/mirrordlg.cpp
+++ b/mirrordlg.cpp
@@ -305,10 +305,10 @@ void mirrorDlg::loadFile(QString & fileName){
         m_verticalAxis = QJsonValue(Ellipse["ellipse vert axis"]).toDouble();
         QJsonObject Annulus = loadDoc["Annulus"].toObject();
         m_useAnnular = QJsonValue(Annulus["use annular Zernike values"]).toBool();
-        m_annularObsPercent = QJsonValue(Annulus["obs percentage"]).toDouble() * 100.;
+        m_annularObsPercent = QJsonValue(Annulus["obs percentage"]).toDouble();
         ui->useAnnulus->setChecked(m_useAnnular);
-        ui->annulusPercent->setValue(m_annularObsPercent);
-        on_annulusPercent_valueChanged(m_annularObsPercent);
+        ui->annulusPercent->setValue(m_annularObsPercent * 100);
+        on_annulusPercent_valueChanged(m_annularObsPercent * 100);
         enableAnnular(m_useAnnular);
 
         ui->fringeSpacingEdit->blockSignals(true);

--- a/mirrordlg.h
+++ b/mirrordlg.h
@@ -53,7 +53,7 @@ public:
     bool fliph;
     bool m_useAnnular;
     bool m_connectAnnulusToObs;
-    double m_annularObsPercent;
+    double m_annularObsPercent; // a value from 0 to 1 (not 0 to 100)
     double m_clearAperature;
     double aperatureReduction;
     static QString m_projectPath;


### PR DESCRIPTION
There was a bug I had missed in mirror configuration.  When reading a json config file back in, if you have
an annulus mirror, it would load the diameter of the inner annulus value 100X too small.

So if the diameter of the mirror was 200mm and the percent of the annulus was 50% it would show 1mm diameter annulus instead of 100mm.

The confusing I think comes from the name of the member variable "m_annularObsPercent" which is really a ratio from 0 to 1 and not a value from 1 to 100.