### PR TITLE
Improve crashlog with minidump

### DIFF
--- a/DFTFringe.pro
+++ b/DFTFringe.pro
@@ -55,6 +55,7 @@ win32 {
     LIBS += -L..\build_openCV\install\x64\mingw\bin -llibopencv_highgui460
     LIBS += -L..\build_openCV\install\x64\mingw\bin -llibopencv_imgcodecs460
     LIBS += -L..\build_openCV\install\x64\mingw\bin -llibopencv_imgproc460
+    LIBS += -ldbghelp # for SetUnhandledExceptionFilter
 
 
     # This is for armadillo to not use wrapper. See https://gitlab.com/conradsnicta/armadillo-code#6-linux-and-macos-compiling-and-linking

--- a/main.cpp
+++ b/main.cpp
@@ -26,10 +26,63 @@
 #include "spdlog/sinks/stdout_color_sinks.h"
 #include "boost/stacktrace.hpp"
 
+#ifdef _WIN32
+    #include <Windows.h>
+    #include <DbgHelp.h>
+    #include <ctime>
+
+    LONG WINAPI MyUnhandledExceptionFilter(EXCEPTION_POINTERS* ExceptionInfo)
+    {
+        // Create a timestamped filename
+        time_t now = time(nullptr);
+        char filename[MAX_PATH];
+        strftime(filename, sizeof(filename), "DFTFringeLogs\\crashdump_%Y%m%d_%H%M%S.dmp", localtime(&now));
+
+        HANDLE hFile = CreateFileA(filename, GENERIC_WRITE, 0, nullptr, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, nullptr);
+        if (hFile == INVALID_HANDLE_VALUE) {
+            return EXCEPTION_EXECUTE_HANDLER;
+        }
+
+        if(ExceptionInfo != nullptr)
+        {
+            MINIDUMP_EXCEPTION_INFORMATION dumpInfo;
+            dumpInfo.ThreadId = GetCurrentThreadId();
+            dumpInfo.ExceptionPointers = ExceptionInfo;
+            dumpInfo.ClientPointers = FALSE;
+
+            MiniDumpWriteDump(
+                GetCurrentProcess(),
+                GetCurrentProcessId(),
+                hFile,
+                MiniDumpNormal,
+                &dumpInfo,
+                nullptr,
+                nullptr
+            );
+        }
+        else
+        {
+            MiniDumpWriteDump(
+                GetCurrentProcess(),
+                GetCurrentProcessId(),
+                hFile,
+                MiniDumpNormal,
+                nullptr, // No exception information
+                nullptr,
+                nullptr
+            );
+        }
+
+        CloseHandle(hFile);
+
+        return EXCEPTION_EXECUTE_HANDLER;
+    }
+#endif
 
 static void my_terminate_handler() {
     try {
         spdlog::get("logger")->critical("Unexpected issue. Stacktrace:\n" + boost::stacktrace::to_string((boost::stacktrace::stacktrace())));
+        MyUnhandledExceptionFilter(nullptr); // Call the unhandled exception filter to create a crash dump
     } catch (...) {}
     std::abort();
 }
@@ -121,6 +174,11 @@ int main(int argc, char *argv[])
 
     // from here, any problematic application exit (for example uncatched exceptions) should call my_terminate_handler
     std::set_terminate(&my_terminate_handler);
+#ifdef _WIN32
+    // in case of specific Windows exceptions, we want to catch them and write a minidump
+    SetUnhandledExceptionFilter(MyUnhandledExceptionFilter);
+#endif
+
 #ifndef DALE_DO_NOT_LOG
     // override QT message handler because qFatal() and qCritical() would exit cleanly without crashlog
     qInstallMessageHandler(myQtMessageOutput); // replace with nullptr if you want to use original bahavior for debug purpose


### PR DESCRIPTION
Close #203 

This adds a minidump to all crashes.   
Crashes from unhandled exception catched with `std::set_terminate` will have stacktrace and minidump.  
Harsher crashes catched with `SetUnhandledExceptionFilter` with only show minidump as spdlog doesn't work during these crashes. To reproduce : open DFTFringe, load no wave front and click on tools -> wave front inspector

- [ ] use `SetUnhandledExceptionFilter` to catch crashes that are not handled today
- [ ] document how to use the minidump to exploit information
- [ ] try exporting registry keys in case of crash

This PR should help us debug unexplained crashes.