### PR TITLE
Improve DFTFringe speed on zernike related computation

### DIFF
--- a/DFTFringe.pro
+++ b/DFTFringe.pro
@@ -262,6 +262,7 @@ SOURCES += SingleApplication/singleapplication.cpp \
     zapm.cpp \
     zernikedlg.cpp \
     zernikeeditdlg.cpp \
+    zernikepolar.cpp \
     zernikeprocess.cpp \
     zernikes.cpp \
     zernikesmoothingdlg.cpp
@@ -389,6 +390,7 @@ HEADERS += bezier/bezier.h \
     wftstats.h \
     zernikedlg.h \
     zernikeeditdlg.h \
+    zernikepolar.h \
     zernikeprocess.h \
     zernikes.h \
     zernikesmoothingdlg.h

--- a/DFTFringe_Dale.pro
+++ b/DFTFringe_Dale.pro
@@ -61,6 +61,7 @@ SOURCES += main.cpp \
     surfacemanager.cpp \
     zapm.cpp \
     zernikedlg.cpp \
+    zernikepolar.cpp \
     zernikeprocess.cpp \
     mirrordlg.cpp \
     zernikes.cpp \
@@ -183,6 +184,7 @@ HEADERS  += mainwindow.h \
     surfaceanalysistools.h \
     surfacemanager.h \
     zernikedlg.h \
+    zernikepolar.h \
     zernikeprocess.h \
     mirrordlg.h \
     zernikes.h \

--- a/dftarea.cpp
+++ b/dftarea.cpp
@@ -1475,11 +1475,11 @@ qDebug() << "rec" << left << top << width << height;
 
 
     zernikePolar &zpolar = *zernikePolar::get_Instance();
-    zpolar.init(r0,t0);
+    zpolar.init(r0,t0,100);
 
 // debug print the difference
 //    for (int i = 0; i < 100; ++i){
-//        qDebug() << "psi Zernike" <<i <<  coords(0,i) << zpolar.zernike(i,r0, t0);
+//        qDebug() << "psi Zernike" <<i <<  coords(0,i) << zpolar.zernike(i);
 //    }
 
     //cv::Mat modul = modu.reshape(0,rows);

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -568,6 +568,7 @@ void MainWindow::updateMetrics(wavefront& wf){
     }
     metrics->setZernTitle(ztitle);
     double z8 = zernTablemodel->values[8];
+    double BestSC;
     if (m_mirrorDlg->doNull && wf.useSANull){
         BestSC = z8/m_mirrorDlg->z8;
     }

--- a/surfacemanager.cpp
+++ b/surfacemanager.cpp
@@ -41,6 +41,7 @@
 #include <algorithm>
 #include <vector>
 #include "zernikeprocess.h"
+#include "zernikepolar.h"
 #include <QTimer>
 #include <qprinter.h>
 #include "rotationdlg.h"

--- a/surfacemanager.cpp
+++ b/surfacemanager.cpp
@@ -447,19 +447,19 @@ cv::Mat SurfaceManager::computeWaveFrontFromZernikes(int wx, int wy, std::vector
             {
                 double S1 = 0;
                 double theta = atan2(y1,x1);
-                zpolar.init(rho,theta);
+                zpolar.init(rho,theta,zernsToUse.size());
                 for (int ii = 0; ii < zernsToUse.size(); ++ii) {
                     int z = zernsToUse[ii];
 
                     if ( z == 3 && m_surfaceTools->m_useDefocus){
-                        S1 += m_surfaceTools->m_defocus * zpolar.zernike(z,rho,theta);
+                        S1 += m_surfaceTools->m_defocus * zpolar.zernike(z);
                     }
                     else {
                         if (en[z]){
                             if (z == 8 && md->doNull)
-                                S1 +=    md->z8 * zpolar.zernike(z,rho, theta);
+                                S1 +=    md->z8 * zpolar.zernike(z);
 
-                            S1 += zerns[z] * zpolar.zernike(z,rho, theta);
+                            S1 += zerns[z] * zpolar.zernike(z);
                         }
                     }
                 }
@@ -753,11 +753,11 @@ void SurfaceManager::useDemoWaveFront(){
             double y1 = (double)(j - (ycen )) /rad;
             rho = sqrt(x1 * x1 + y1 * y1);
             double theta = atan2(y1,x1);
-            zpolar.init(rho,theta);
+            zpolar.init(rho,theta,10);
 
             if (rho <= 1.)
             {
-                double S1 = md->z8 * -.9 * zpolar.zernike(8,rho,theta) + .02* zpolar.zernike(9, rho,theta);
+                double S1 = md->z8 * -.9 * zpolar.zernike(8) + .02* zpolar.zernike(9);
 
                 result.at<double>(j,i) = S1;
             }

--- a/zernikeeditdlg.cpp
+++ b/zernikeeditdlg.cpp
@@ -3,6 +3,7 @@
 #include <QFileDialog>
 #include <fstream>
 #include "zernikeprocess.h"
+#include "zernikepolar.h"
 #include "mirrordlg.h"
 #include "myutils.h"
 zernikeEditDlg::zernikeEditDlg(SurfaceManager * sfm, QWidget *parent) :

--- a/zernikeeditdlg.cpp
+++ b/zernikeeditdlg.cpp
@@ -65,12 +65,12 @@ void zernikeEditDlg::on_createSurface_clicked()
             if (rho <= 1.)
             {
                 double theta = atan2(uy,ux);
-                zpolar.init(rho,theta);
+                zpolar.init(rho, theta, tableModel->rowCount());
                 double s1 = 0;
                 for (int z = 0; z < tableModel->rowCount(); ++z){
                     double v = tableModel->values[z];
                     if (m_zernEnables[z]){
-                        s1 += v * zpolar.zernike(z, rho, theta);
+                        s1 += v * zpolar.zernike(z);
                     }
                 }
                 result.at<double>(y,x) = s1;

--- a/zernikepolar.cpp
+++ b/zernikepolar.cpp
@@ -19,10 +19,7 @@
 #include "zernikepolar.h"
 #include <QDebug>
 
-/*
-Public Function Zernike(n As Integer, X As Double, Y As Double) As Double
-' N is Zernike number as given by James Wyant
-*/
+
 zernikePolar *zernikePolar::m_instance = 0;
 zernikePolar *zernikePolar::get_Instance(){
     if (m_instance == 0){

--- a/zernikepolar.cpp
+++ b/zernikepolar.cpp
@@ -1,0 +1,137 @@
+/******************************************************************************
+**
+**  Copyright 2016 Dale Eason
+**  This file is part of DFTFringe
+**  is free software: you can redistribute it and/or modify
+** it under the terms of the GNU General Public License as published by
+** the Free Software Foundation version 3 of the License
+
+** DFTFringe is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+** GNU General Public License for more details.
+**
+** You should have received a copy of the GNU General Public License
+** along with DFTFringe.  If not, see <http://www.gnu.org/licenses/>.
+
+****************************************************************************/
+
+#include "zernikepolar.h"
+#include <QDebug>
+
+/*
+Public Function Zernike(n As Integer, X As Double, Y As Double) As Double
+' N is Zernike number as given by James Wyant
+*/
+zernikePolar *zernikePolar::m_instance = 0;
+zernikePolar *zernikePolar::get_Instance(){
+    if (m_instance == 0){
+        m_instance = new zernikePolar;
+    }
+    return m_instance;
+}
+
+// Having all terms computed at once here let's compiler optimize the code better
+void zernikePolar::init(double rho, double theta, size_t nbTerms){
+    if(nbTerms > 49){
+        qWarning() << "zernikePolar::init: maxorder is limited to 49, setting to 49";
+        nbTerms = 49;
+    }
+    
+    m_nbTermsComputed = nbTerms;
+    
+    zernTerms[0] = 1.;
+    
+    rho2 = rho * rho;
+    costheta = cos(theta);
+    sintheta = sin(theta);
+    cos2theta = cos(2. * theta);
+    sin2theta = sin(2. * theta);
+    zernTerms[1] = rho * costheta;
+    zernTerms[2] = rho * sintheta;
+    zernTerms[3] = -1. + 2. * rho2;
+    zernTerms[4] = rho2 * cos2theta;
+    zernTerms[5] = rho2 * sin2theta;
+    zernTerms[6] = rho * (-2. + 3. * rho2) * costheta;
+    zernTerms[7] = rho * (-2. + 3. * rho2) * sintheta;
+    zernTerms[8] = 1. + rho2 * (-6 + 6. * rho2);
+
+    // only compute what is actually needed
+    // but to avoid complex code I use only 4 ranges
+    if(nbTerms > 8)
+    {
+        
+        rho3 = rho2 * rho;
+        rho4 = rho3 * rho;
+        rho5 = rho4 * rho;
+        rho6 = rho5 * rho;
+        rho8 = rho6 * rho;
+        cos3theta = cos(3. * theta);
+        sin3theta = sin(3. * theta);
+        cos4theta = cos(4. * theta);
+        sin4theta = sin(4. * theta);
+
+        zernTerms[9] = rho3 * cos3theta;
+        zernTerms[10] = rho3 * sin3theta;
+        zernTerms[11] = rho2 * (-3 + 4 * rho2) * cos2theta;
+        zernTerms[12] = rho2 * (-3 + 4 * rho2) * sin2theta ;
+        zernTerms[13] = rho * (3. - 12. * rho2 + 10. * rho4) * costheta;
+        zernTerms[14] = rho * (3. - 12. * rho2 + 10. * rho4) * sintheta;
+        zernTerms[15] = -1 + 12 * rho2 - 30. * rho4 + 20. * rho6;
+        zernTerms[16] = rho4 * cos4theta;
+        zernTerms[17] = rho4 * sin4theta;
+        zernTerms[18] = rho3 *( -4. + 5. * rho2) * cos3theta;
+        zernTerms[19] = rho3 *( -4. + 5. * rho2) * sin3theta;
+        zernTerms[20] = rho2 * (6. - 20. * rho2 + 15 * rho4)* cos2theta;
+        zernTerms[21] = rho2 * (6. - 20. * rho2 + 15 * rho4)* sin2theta;
+        zernTerms[22] = rho * (-4. + 30. * rho2 - 60. * rho4 + 35 * rho6)* costheta;
+        zernTerms[23] = rho * (-4. + 30. * rho2 - 60. * rho4 + 35 * rho6)* sintheta;
+        zernTerms[24] = 1. - 20. * rho2 + 90. *  rho4 - 140. * rho6 + 70. * rho8;
+    }
+
+    if(nbTerms > 24) {
+        rho10 = rho8 * rho2;
+        cos5theta = cos(5. * theta);
+        sin5theta = sin(5. * theta);
+
+        zernTerms[25] = rho5 * cos5theta;
+        zernTerms[26] = rho5 * sin5theta;
+        zernTerms[27] = rho4 * (-5. + 6. * rho2) * cos4theta;
+        zernTerms[28] = rho4 * (-5. + 6. * rho2) * sin4theta;
+        zernTerms[29] = rho3 * (10. - 30. * rho2 + 21. * rho4) * cos3theta;
+        zernTerms[30] = rho3 * (10. - 30. * rho2 + 21. * rho4) * sin3theta;
+        zernTerms[31] = rho2 *(-10. + 60. * rho2 - 105. * rho4 + 56. * rho6) * cos2theta;
+        zernTerms[32] = rho2 *(-10. + 60. * rho2 - 105. * rho4 + 56. * rho6) * sin2theta;
+        zernTerms[33] = rho * (5. - 60. * rho2 + 210 * rho4 -280. * rho6 + 126. * rho8) * costheta;
+        zernTerms[34] = rho * (5. - 60. * rho2 + 210 * rho4 -280. * rho6 + 126. * rho8) * sintheta;
+        zernTerms[35] = -1 + 30. * rho2 -210 * rho4 + 560. * rho6 - 630 * rho8 + 252. * rho10;
+    }
+
+    if(nbTerms > 35)
+    {
+        zernTerms[36] = rho6 * cos(6. * theta);
+        zernTerms[37] = rho6 * sin(6. * theta);
+        zernTerms[38] = rho5 * (-6. + 7 * rho2) * cos5theta;
+        zernTerms[39] = rho5 * (-6. + 7 * rho2) * sin5theta;
+        zernTerms[40] = rho4 * (15. -42. * rho2 + 28. * rho4) * cos4theta;
+        zernTerms[41] = rho4 * (15. -42. * rho2 + 28. * rho4) * sin4theta;
+        zernTerms[42] = rho3 * (-20 + 105. * rho2 - 168. * rho4 + 84 * rho6) * cos3theta;
+        zernTerms[43] = rho3 * (-20. + 105. * rho2 - 168. * rho4 + 84. * rho6) * sin3theta;
+        zernTerms[44] = rho2 * (15. - 140. * rho2 + 420. * rho4 - 504. * rho6 +  210. * rho8) * cos2theta;
+        zernTerms[45] = rho2 * (15. - 140. * rho2 + 420. * rho4 - 504. * rho6 +  210. * rho8) * sin2theta;
+        zernTerms[46] = rho *(-6. + 105 * rho2 - 560. * rho4 + 1260. * rho6 -1260. * rho8 +462. * rho10) * costheta;
+        zernTerms[47] = rho *(-6. + 105 * rho2 - 560. * rho4 + 1260. * rho6 -1260. * rho8 +462. * rho10) * sintheta;
+        zernTerms[48] = 1. - 42. * rho2 + 420. * rho4 - 1680. * rho6 + 3150. * rho8 -2772. * rho10 + 924. * rho8 * rho2;
+    }
+}
+
+double zernikePolar::zernike(size_t n){
+    if(n < m_nbTermsComputed) {
+        return zernTerms[n];
+    }
+    else
+    {
+        throw std::out_of_range("Zernike order exceeds maximum computed order");
+        return 0.;
+    }
+}

--- a/zernikepolar.h
+++ b/zernikepolar.h
@@ -1,0 +1,56 @@
+/******************************************************************************
+**
+**  Copyright 2016 Dale Eason
+**  This file is part of DFTFringe
+**  is free software: you can redistribute it and/or modify
+** it under the terms of the GNU General Public License as published by
+** the Free Software Foundation version 3 of the License
+
+** DFTFringe is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+** GNU General Public License for more details.
+**
+** You should have received a copy of the GNU General Public License
+** along with DFTFringe.  If not, see <http://www.gnu.org/licenses/>.
+
+****************************************************************************/
+
+#ifndef ZERNIKEPOLAR_H
+#define ZERNIKEPOLAR_H
+
+#include <QObject>
+
+class zernikePolar : public QObject
+{
+    Q_OBJECT
+public:
+    explicit zernikePolar(){};
+    static zernikePolar *get_Instance();  //TODO check if we really need a singleton here
+    void init(double rho, double theta, size_t nbTerms = 48);
+    double zernike(size_t z);
+private:
+     static zernikePolar *m_instance;
+     double rho2;
+     double rho3;
+     double rho4;
+     double rho5;
+     double rho6;
+     double rho8;
+     double rho10;
+     double costheta;
+     double sintheta;
+     double cos2theta;
+     double sin2theta;
+     double cos3theta;
+     double sin3theta;
+     double cos4theta;
+     double sin4theta;
+     double cos5theta;
+     double sin5theta;
+     size_t m_nbTermsComputed;
+     double zernTerms[49]; // TODO if no singleton, use correct length
+};
+
+
+#endif

--- a/zernikeprocess.cpp
+++ b/zernikeprocess.cpp
@@ -275,12 +275,12 @@ zernikePolar *zernikePolar::get_Instance(){
 
 void zernikePolar::init(double rho, double theta){
         rho2 = rho * rho;
-        rho3 = pow(rho,3.);
-        rho4 = pow(rho,4.);
-        rho5 = pow(rho,5.);
-        rho6 = pow(rho,6.);
-        rho8 = pow(rho,8.);
-        rho10 = pow(rho,10.);
+        rho3 = rho2 * rho;
+        rho4 = rho3 * rho;
+        rho5 = rho4 * rho;
+        rho6 = rho5 * rho;
+        rho8 = rho6 * rho;
+        rho10 = rho8 * rho2;
         costheta = cos(theta);
         sintheta = sin(theta);
         cos2theta = cos(2. * theta);

--- a/zernikeprocess.cpp
+++ b/zernikeprocess.cpp
@@ -27,19 +27,10 @@
 #include "myutils.h"
 //#include "arbitrarywavefrontdlg.h"
 #include "userdrawnprofiledlg.h"
+
+
 std::vector<bool> zernEnables;
 std::vector<double> zNulls;
-double BestSC = -1.;
-int Zw[] = {								/*  n    */
-    1,									  //    0
-    4,4,3,								  //	1
-    6,6,8,8,5,  //8						  //	2
-    8,8,10,10,12,12,7, // 15					3
-    10,10,12,12,14,14,16,16,9,  //24			4
-    12,12,14,14,16,16,18,18,20,20,11,  //35		5
-    14,14,16,16,18,18,20,20,22,22,24,24,13  // 48
-};
-
 
 
 //
@@ -132,15 +123,7 @@ cv::Mat zpmCx(QVector<double> rho, QVector<double> theta, int maxorder) {
   }
   return zm;
 }
-/*
-Public Function ZernikeW(n As Integer) As Double
-' N is Zernike number as given by James Wyant
-' routine calculates the inverse of the weight in the variance computation
-*/
-int ZernikeW(int n)
-{
-    return(Zw[n]);
-}
+
 
 long fact( int n1, int n2)
 {
@@ -152,9 +135,8 @@ long fact( int n1, int n2)
     return f;
 
 }
-void gauss_jordan(int n, double* Am, double* Bm)
-{
-    /*
+
+/*
 Private Sub GJ(n As Integer)
 Dim indxc(50) As Integer, indxr(50) As Integer, ipiv(50) As Integer
 Dim i As Integer, icol As Integer, irow As Integer, j As Integer
@@ -168,6 +150,10 @@ Dim big As Double, dum As Double, pivinv As Double, temp As Double
    'on entry, Am(1 to N, 1 to N) is the matrix coefficients
    'on exit, Am is the inverse matrix
  */
+/*
+void gauss_jordan(int n, double* Am, double* Bm)
+{
+    
     int* ipiv = new int[n];
     int* indxr = new int[n];
     int* indxc = new int[n];
@@ -261,11 +247,14 @@ Dim big As Double, dum As Double, pivinv As Double, temp As Double
     delete[] ipiv;
     delete[] indxr;
     delete[] indxc;
-}
+}*/
 
 
-
-double Zernike(int n, double X, double Y)
+/*
+Public Function Zernike(n As Integer, X As Double, Y As Double) As Double
+' N is Zernike number as given by James Wyant
+*/
+/*double Zernike(int n, double X, double Y)
 {
     static double X2 = 0., X3 = 0., X4 = 0.;
     static double Y2 = 0., Y3 = 0., Y4 = 0.;
@@ -431,9 +420,7 @@ double Zernike(int n, double X, double Y)
         return(0.);
     }
     return d;
-
-
-}
+}*/
 
 
 

--- a/zernikeprocess.h
+++ b/zernikeprocess.h
@@ -25,6 +25,8 @@
 #include "mainwindow.h"
 #include "armadillo"
 #include <stdlib.h>
+
+//TODO remove this if possible and use a class
 extern std::vector<bool> zernEnables;
 extern int Zw[];
 extern double BestSC;
@@ -137,14 +139,15 @@ public slots:
 
 };
 
+//TODO separate class into different files
 class zernikePolar : public QObject
 {
     Q_OBJECT
 public:
     explicit zernikePolar(){};
-    static zernikePolar *get_Instance();
-    void init(double rho, double theta);
-    double zernike(int z, double rho, double theta);
+    static zernikePolar *get_Instance();  //TODO check if we really need a singleton here
+    void init(double rho, double theta, size_t nbTerms = 48);
+    double zernike(size_t z);
 private:
      static zernikePolar *m_instance;
      double rho2;
@@ -164,6 +167,8 @@ private:
      double sin4theta;
      double cos5theta;
      double sin5theta;
+     size_t m_nbTermsComputed;
+     double zernTerms[49]; // TODO if no singleton, use correct length
 };
 
 void debugZernRoutines();

--- a/zernikeprocess.h
+++ b/zernikeprocess.h
@@ -140,36 +140,7 @@ public slots:
 };
 
 //TODO separate class into different files
-class zernikePolar : public QObject
-{
-    Q_OBJECT
-public:
-    explicit zernikePolar(){};
-    static zernikePolar *get_Instance();  //TODO check if we really need a singleton here
-    void init(double rho, double theta, size_t nbTerms = 48);
-    double zernike(size_t z);
-private:
-     static zernikePolar *m_instance;
-     double rho2;
-     double rho3;
-     double rho4;
-     double rho5;
-     double rho6;
-     double rho8;
-     double rho10;
-     double costheta;
-     double sintheta;
-     double cos2theta;
-     double sin2theta;
-     double cos3theta;
-     double sin3theta;
-     double cos4theta;
-     double sin4theta;
-     double cos5theta;
-     double sin5theta;
-     size_t m_nbTermsComputed;
-     double zernTerms[49]; // TODO if no singleton, use correct length
-};
+
 
 void debugZernRoutines();
 

--- a/zernikeprocess.h
+++ b/zernikeprocess.h
@@ -26,67 +26,11 @@
 #include "armadillo"
 #include <stdlib.h>
 
-//TODO remove this if possible and use a class
+//TODO remove this if possible and use a class. It's undocumented, difficult to undesrstand and maintain
 extern std::vector<bool> zernEnables;
-extern int Zw[];
-extern double BestSC;
-double zernike(int n, double x, double y);
-void gauss_jordan(int n, double* Am, double* Bm);
-void ZernikeSmooth(Mat wf, Mat mask);
+//double zernike(int n, double x, double y);
+//void gauss_jordan(int n, double* Am, double* Bm);
 
-typedef struct  {
-    std::vector<bool> enables;
-    std::vector<double> norms;
-    int maxOrder;
-    int noOfTerms;
-    std::vector<int> rowIndex;
-    std::vector<int> colIndex;
-    arma::mat zernsArSample;
-    arma::mat rhoTheta;
-    int widthOfMatrix;
-    double radius;
-    double centerX;
-    double centerY;
-    double insideRadius;
-    bool valid;
-} zernikeData;
-
-class zernProcess : public QObject
-{
-    Q_OBJECT
-private:
-    static zernProcess *m_Instance;
-    bool m_needsInit;
-
-public:
-    zernikeData m_zData;
-
-    explicit zernProcess(QObject *parent = 0);
-    static zernProcess *get_Instance();
-    void unwrap_to_zernikes(wavefront &wf, int zterms = Z_TERMS);
-    cv::Mat null_unwrapped(wavefront&wf,  std::vector<double> zerns, std::vector<bool> enables,int start_term =0, int last_term = Z_TERMS);
-    void ZernFitWavefront( wavefront &wf);
-    void initGrid(wavefront &wf, int maxOrder);
-    void initGrid(int width, double radius, double cx, double cy, int maxOrder, double inside = 0);
-    void unwrap_to_zernikes(zern_generator *zg, cv::Mat wf, cv::Mat mask);
-    cv::Mat makeSurfaceFromZerns(int border, bool doColor);
-    //arma::mat rhotheta( int width, double radius, double cx, double cy,
-                                       //double insideRad, const wavefront *wf = 0);
-    //arma::mat zpmC(arma::rowvec rho, arma::rowvec theta, int maxorder);
-    //arma::mat zapmC(const arma::rowvec& rho, const arma::rowvec& theta, const int& maxorder=12);
-    void fillVoid(wavefront &wf);
-    void setMaxOrder(int n);
-    int getNumberOfTerms();
-    int m_abc;
-    mirrorDlg *md;
-    MainWindow *mw;
-    //arma::mat m_zerns;
-    QVector<double> m_norms;
-signals:
-void statusBarUpdate(QString, int);
-public slots:
-
-};
 
 
 class zernikeProcess : public QObject
@@ -139,9 +83,5 @@ public slots:
 
 };
 
-//TODO separate class into different files
-
-
-void debugZernRoutines();
 
 #endif // ZERNIKEPROCESS_H

--- a/zernikes.cpp
+++ b/zernikes.cpp
@@ -38,6 +38,15 @@ void dump_matrix (double *a, int nrows, int ncols,const char *desc)
     }
 }
 
+static const int Zw[] = {                    /*  n    */
+    1,                                       //  0
+    4,4,3,                                   //  1
+    6,6,8,8,5,  //8                          //  2
+    8,8,10,10,12,12,7, // 15                     3
+    10,10,12,12,14,14,16,16,9,  //24             4
+    12,12,14,14,16,16,18,18,20,20,11,  //35      5
+    14,14,16,16,18,18,20,20,22,22,24,24,13  // 48
+};
 
 double computeRMS(int term,  double val){
 
@@ -251,7 +260,7 @@ double *rand_zern ( zern_spec *s)
 
 void zern_generator::set_zcoefs(double *data)
 {
-    m_zcoef.assign(data,data + get_terms_cnt());		// temp.  chanage to param after debug
+    m_zcoef.assign(data,data + get_terms_cnt());        // temp.  chanage to param after debug
 }
 
 


### PR DESCRIPTION
as discussed in #202

I mainly moved some things around. No big change in the zernike code to keep it safe and readable.

However measurement showed 50% gain on `unwrap_to_zernikes`. Which represents some 5% total speedup. Those are callgrind numbers. I did not time it on an install to get a user feeling for the moment.