### PR TITLE
fix code that mixes wavefront index and name

### DIFF
--- a/surfacemanager.cpp
+++ b/surfacemanager.cpp
@@ -1788,8 +1788,9 @@ void SurfaceManager::subtractWavefronts(){
     QList<QString> list;
     QList<int> doThese =  m_surfaceTools->SelectedWaveFronts();
     for (int i = 0; i < m_wavefronts.size(); ++i){
-        if (!m_wavefronts[i]->name.contains(doThese[0]))
+        if (!doThese.contains(i)) {
              list.append(m_wavefronts[i]->name);
+        }
     }
     subtractWavefronatsDlg dlg(list);
     QScreen *screen = QGuiApplication::primaryScreen();


### PR DESCRIPTION
This has been introduced in #193 

I got complain from newer compiler while migrating to QT6 and I think he is right. One more reason to move.
Actually `doThese` contains index of wavefront. And it's compared to wavefront name which makes no sense. 

Please confirm my (AI powered, human checked) proposal is what you intended to do. It would be great to infer the impact of this to add to changelog bugfix.