### PR TITLE
prepare release 7.4.0

### DIFF
--- a/RevisionHistory.html
+++ b/RevisionHistory.html
@@ -446,5 +446,19 @@ Displays error of pixel under contour plot cursor and move the profie angle to m
 <ul><li>Version 7.3.4</li>
 <ul>
 <li>Modified percent correction to use user settable middle exclude radius and added ability to show values in inches.</li>
+</ul>
+</ul>
+
+<ul><li>Version 7.4.0</li>
+<ul>
+<li>New button to remove wavefront auto invert.</li>
+<li>Fixed bug that was causing intermitent crashes.</li>
+<li>Fix discrepency in wavefront 2D cut angle versus wavefront profile.</li>
+<li>Fix wavefront subtraction.</li>
+<li>Minor code quality improvements.</li>
+<li>Updated project dependencies.</li>
+</ul>
+</ul>
+
 
 </ul>

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -2103,18 +2103,6 @@ void MainWindow::on_actionastig_in_polar_triggered()
 }
 
 
-void MainWindow::on_actiondebugSomething_triggered()
-{
-
-
-
-
-
-
-
-}
-
-
 void MainWindow::on_actionStop_auto_invert_triggered()
 {
     m_surfaceManager->m_askAboutReverse = true;

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -273,8 +273,6 @@ private slots:
 
     void on_actionastig_in_polar_triggered();
 
-    void on_actiondebugSomething_triggered();
-
     void on_actionStop_auto_invert_triggered();
 
 private:

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -83,7 +83,6 @@
     <addaction name="separator"/>
     <addaction name="actionSave_PDF_report"/>
     <addaction name="actionCreate_Movie_of_wavefronts"/>
-    <addaction name="actiondebugSomething"/>
    </widget>
    <widget class="QMenu" name="menuView">
     <property name="title">
@@ -1514,11 +1513,6 @@ em;
   <action name="actionastig_in_polar">
    <property name="text">
     <string>Show astig in polar form of selected wave fronts</string>
-   </property>
-  </action>
-  <action name="actiondebugSomething">
-   <property name="text">
-    <string>debugSomething</string>
    </property>
   </action>
   <action name="actionStop_auto_invert">


### PR DESCRIPTION
remove a thing introduced in #201 that shall not appear to end user.
IMHO This new auto invert option should be in preferences. Not in the main menu.

Anyway: new feature measure minor version update not only patch. => v7.4.0 