### PR TITLE
fix deprecated API

### DIFF
--- a/contourtools.ui
+++ b/contourtools.ui
@@ -23,7 +23,7 @@
    </size>
   </property>
   <property name="features">
-   <set>QDockWidget::AllDockWidgetFeatures</set>
+   <set>QDockWidget::DockWidgetClosable|QDockWidget::DockWidgetFloatable|QDockWidget::DockWidgetMovable</set>
   </property>
   <property name="windowTitle">
    <string>Contour</string>


### PR DESCRIPTION
this is really minor and fixes `contourtools.ui: Warning: Deprecated enum value QDockWidget::AllDockWidgetFeatures was encountered.`

This does not show up in automated warnings because it's not exactly the expected syntax. I found it reading the logs. 