### PR TITLE
ensure there is no slicing risk on inherited classes

### DIFF
--- a/Circleoutline.h
+++ b/Circleoutline.h
@@ -26,7 +26,7 @@
 #include <opencv2/opencv.hpp>
 #include <QJsonObject>
 void fillCircle(cv::Mat &m, double cx, double cy, double rad, void *color);
-class CircleOutline: public boundary
+class CircleOutline final: public boundary
 {
     public:
         CircleOutline();
@@ -35,7 +35,7 @@ class CircleOutline: public boundary
         CircleOutline(const QJsonObject &obj);
         void toJson(QJsonObject &obj);
 
-        virtual ~CircleOutline();
+        ~CircleOutline();
         void draw(QPainter& painter, double scale, double scale2 = -1.);
         bool isInside(QPointF& p , int offset = 0);
         bool isInside(double x, double y, int offset=0);
@@ -48,17 +48,15 @@ class CircleOutline: public boundary
         double m_radius;
         gPlus m_p1;
         gPlus m_p2;
-    protected:
-
-    private:
 };
 
-class ellipseOutline: public boundary
+class ellipseOutline final: public boundary
 {
 public:
     ellipseOutline();
     ellipseOutline(QPointF center, double minorAxis, double majorAxis);
     ellipseOutline(QPointF left, QPointF right, double ecc);
+    void draw(QPainter& painter, double scale, double scale2 = -1.);
     bool isInside(QPointF& p , int offset = 0);
     void enlarge(int del);
     void translate(QPointF del);
@@ -76,11 +74,12 @@ public:
     gPlus m_p2;
 };
 
-class rectangleOutline: public boundary
+class rectangleOutline final: public boundary
 {
 public:
     rectangleOutline();
     rectangleOutline(QPointF upperLeft, QPointF lowerRight);
+    void draw(QPainter& painter, double scale, double scale2 = -1.);
     bool isInside(QPointF& p , int offset = 0);
     void enlarge(int del);
     void translate(QPointF del);

--- a/boundary.h
+++ b/boundary.h
@@ -18,17 +18,26 @@
 #ifndef BOUNDARY_H
 #define BOUNDARY_H
 #include <QPainter>
+
+// asbtract base class. Zero risk of slicing.
 class boundary
 {
+    protected:
+        boundary() = default;
+        ~boundary() = default;
+        // Copy operations
+        boundary(const boundary&) = default;
+        boundary& operator=(const boundary&) = default;
+        // Move operations
+        boundary(boundary&&) noexcept = default;
+        boundary& operator=(boundary&&) noexcept = default;
     public:
-        virtual ~boundary() {}
         virtual void draw(QPainter& painter, double scale, double scale2 = -1.) = 0;
         virtual void enlarge(int del) = 0;
         virtual void translate(QPointF del) = 0;
         virtual void scale(double factor) = 0;
         virtual bool isValid() = 0;
         virtual bool isInside(QPointF& p, int offset = 0) = 0;
-    protected:
     private:
 };
 QDataStream & operator<<(QDataStream & stream, const boundary &outline);

--- a/gplus.h
+++ b/gplus.h
@@ -24,7 +24,7 @@ class gPlus
     public:
         gPlus(QPointF p);
         gPlus();
-        virtual ~gPlus();
+        ~gPlus();
         void draw(QPainter& dc, double scale, int size = 10);
         QPointF m_p;
     protected:


### PR DESCRIPTION
Clazy the tool that checks some Qt and C++ compliance actually has level2 checks that I did not activate because 2Y ago we had 10k warnings on level1

I looked into [clazy-copyable-polymorphic](https://github.com/KDE/clazy/blob/master/docs/checks/README-copyable-polymorphic.md) because this is a real risk.

What I mainly did is
- make `boundary` an abstract class. Constructor, copy and move being `protected`, it cannot be instantiated. Thus no slicing is possible. Never.
- adding `final` and removing some wrong `virtual` is only to help Clazy identify there is no risk and remove the warning.

To conclude: I can now confirm there was no slicing happening. The changes remove the risk to have it happen someday.


I choose the path of minimal changes to not mess with the code and simplify review. If you think `rectangleOutline` and `ellipseOutline` will never be coded, we could simplify the code a lot. Remove inheritance and theses classes.
I like the KISS principle "Keep It Short and Simple". Less code means less maintenance and less problems. 

Kindly let me know if you prefer this pull request code with minimal changes or a more complete rewrite to simplify the code.