### PR TITLE
pass by reference or by value when necessary

### DIFF
--- a/IgramArea.h
+++ b/IgramArea.h
@@ -85,7 +85,7 @@ class outlinePair{
 public:
     QImage m_image;
     CircleOutline m_outline;
-    outlinePair(QImage img, CircleOutline outline): m_image(img), m_outline(outline){}
+    outlinePair(const QImage &img, const CircleOutline &outline): m_image(img), m_outline(outline){}
 };
 
 class undoStack {
@@ -94,7 +94,7 @@ class undoStack {
 
 public:
     undoStack(){};
-    void push(QImage img, CircleOutline outline);
+    void push(const QImage &img, const CircleOutline &outline);
     outlinePair  current(){return m_stack.back();};
     outlinePair undo();
     outlinePair redo();
@@ -142,8 +142,8 @@ public:
     CircleOutline m_center;
     void hideOutline(bool checked);
     bool m_hideOutlines;
-    void loadOutlineFileOldV6(QString filename);
-    void loadOutlineFile(QString filename);
+    void loadOutlineFileOldV6(const QString &filename);
+    void loadOutlineFile(const QString &filename);
     void undo();
     void redo();
     void writeOutlinesOldV6(QString fileName);
@@ -152,7 +152,7 @@ public:
     void shiftoutline(QPointF p);
     void setZoomMode(zoomMode mode);
     void showAliasDialog();
-    cv::Mat igramToGray(cv::Mat roi);
+    cv::Mat igramToGray(const cv::Mat &roi);
     cv::Mat qImageToMat(QImage &roi);
 private slots:
     void aperatureChanged();
@@ -160,7 +160,7 @@ public slots:
     void gammaChanged(bool, double);
     void generateSimIgram();
     void clearImage();
-    void dftReady(QImage img);
+    void dftReady(const QImage &img);
     void outlineTimerTimeout();
     void shiftUp();
     void shiftDown();
@@ -168,7 +168,7 @@ public slots:
     void shiftLeft();
     void zoomIn();
     void zoomOut();
-    void igramOutlineParmsChanged(outlineParms parms);
+    void igramOutlineParmsChanged(const outlineParms &parms);
     void increase( int i = 1);
     void decrease();
     void zoomFull();
@@ -218,8 +218,8 @@ private:
 
     double leftMargin;
     double searchOutlineScale;
-    cv::Point2d findBestOutsideOutline(cv::Mat gray, int start, int end, int step, int *radius, int pass);
-    cv::Point2d findBestCenterOutline(cv::Mat gray, int start, int end, int step, int *radius, bool useExisting);
+    cv::Point2d findBestOutsideOutline(const cv::Mat &gray, int start, int end, int step, int *radius, int pass);
+    cv::Point2d findBestCenterOutline(const cv::Mat &gray, int start, int end, int step, int *radius, bool useExisting);
     QString m_outlineMsg;
     double m_edgeMaskWidth;
     void saveRegions();

--- a/arbitrarywavwidget.cpp
+++ b/arbitrarywavwidget.cpp
@@ -54,7 +54,7 @@ ArbitraryWavWidget::~ArbitraryWavWidget(){
     pts.empty();
 }
 
-bool comparePoints(const QPointF &a, const QPointF &b) {
+bool comparePoints(QPointF a, QPointF b) {
     return a.x() < b.x();
 }
 

--- a/astigpolargraph.h
+++ b/astigpolargraph.h
@@ -25,7 +25,7 @@ public:
     QString m_name;
     double m_xastig;
     double m_yastig;
-    astigSample(QString name, double xastig, double yastig): m_name(name), m_xastig(xastig), m_yastig(yastig){};
+    astigSample(const QString &name, double xastig, double yastig): m_name(name), m_xastig(xastig), m_yastig(yastig){};
 };
 
 class astigPolargraph : public QDialog

--- a/astigscatterplot.cpp
+++ b/astigscatterplot.cpp
@@ -46,12 +46,12 @@ astigScatterPlot::astigScatterPlot(QWidget *parent):QwtPlot( parent ),m_max(.3)
     replot();
 }
 
-void astigScatterPlot::selectedwave(QString m){
+void astigScatterPlot::selectedwave(const QString &m){
     emit waveSeleted(m);
 }
 
 
-void astigScatterPlot::addValue(QString name, QPointF p){
+void astigScatterPlot::addValue(const QString &name, QPointF p){
     QwtPlotMarker *m = new QwtPlotMarker(name);
     if (fabs(p.x()) > m_max)
         m_max = fabs(p.x());

--- a/astigscatterplot.h
+++ b/astigscatterplot.h
@@ -17,11 +17,11 @@ class astigScatterPlot : public QwtPlot
     double m_max;
 public:
     astigScatterPlot(QWidget *parent = 0);
-    void addValue(QString name, QPointF p);
+    void addValue(const QString &name, QPointF p);
 signals:
     void waveSeleted(QString m);
 public slots:
-    void selectedwave(QString);
+    void selectedwave(const QString&);
 };
 
 #endif // ASTIGSCATTERPLOT_H

--- a/astigstatsdlg.cpp
+++ b/astigstatsdlg.cpp
@@ -110,7 +110,7 @@ public:
         : QwtPlotPicker(xAxis, yAxis, QwtPicker::NoRubberBand, QwtPicker::AlwaysOn, canvas) {
     }
 
-    void addTooltipToPoint(const QPointF &point, const QString &tooltip){
+    void addTooltipToPoint(QPointF point, const QString &tooltip){
         tooltips_.emplace_back(point, tooltip);
     }
 

--- a/astigstatsdlg.cpp
+++ b/astigstatsdlg.cpp
@@ -138,7 +138,7 @@ private:
 };
 
 
-astigStatsDlg::astigStatsDlg(QVector<wavefront *> wavefronts, QWidget *parent) :
+astigStatsDlg::astigStatsDlg(const QVector<wavefront *> &wavefronts, QWidget *parent) :
     QDialog(parent),
     ui(new Ui::astigStatsDlg), m_wavefronts(wavefronts), editor(0), PDFMode(false),
     distributionWindow(0), runningAvgN(20), showSamples(false),
@@ -181,7 +181,7 @@ class measure{
 public:
     QString name;
     QPointF p;
-    measure(QString n, QPointF _p):name(n),p(_p){};
+    measure(const QString &n, QPointF _p):name(n),p(_p){};
     measure(){};
 };
 
@@ -480,7 +480,7 @@ void astigStatsDlg::plot(){
     ui->mPlot->replot();
 }
 
-void astigStatsDlg::showItem(QVariant item, bool on, int /*ndx*/){
+void astigStatsDlg::showItem(const QVariant &item, bool on, int /*ndx*/){
     qDebug() << "item " << item;
     QwtPlotItem *t = qvariant_cast<QwtPlotItem *>(item);
     t->setVisible(on);

--- a/astigstatsdlg.h
+++ b/astigstatsdlg.h
@@ -24,7 +24,7 @@ class astigStatsDlg : public QDialog
     Q_OBJECT
 
 public:
-    explicit astigStatsDlg( QVector<wavefront *> wavefronts,QWidget *parent = 0);
+    explicit astigStatsDlg( const QVector<wavefront *> &wavefronts,QWidget *parent = 0);
     ~astigStatsDlg();
     void plot();
 private slots:
@@ -41,7 +41,7 @@ private slots:
     void on_clearPb_clicked();
 
     void on_onlyAverages_clicked();
-    void showItem(QVariant item, bool on, int ndx);
+    void showItem(const QVariant &item, bool on, int ndx);
 
     void on_savePB_clicked();
     void showSamplesChanged(bool);

--- a/averagewavefrontfilesdlg.cpp
+++ b/averagewavefrontfilesdlg.cpp
@@ -10,7 +10,7 @@
 #include <opencv2/imgproc.hpp>
 
 void showData(const std::string &txt, cv::Mat mat, bool useLog);
-averageWaveFrontFilesDlg::averageWaveFrontFilesDlg(QStringList list, SurfaceManager *m, QWidget *parent) :
+averageWaveFrontFilesDlg::averageWaveFrontFilesDlg(const QStringList &list, SurfaceManager *m, QWidget *parent) :
     QDialog(parent),
     ui(new Ui::averageWaveFrontFilesDlg)
 {

--- a/averagewavefrontfilesdlg.h
+++ b/averagewavefrontfilesdlg.h
@@ -16,7 +16,7 @@ class averageWaveFrontFilesDlg : public QDialog
     SurfaceManager *sm;
 
 public:
-    explicit averageWaveFrontFilesDlg(QStringList list, SurfaceManager *sm, QWidget *parent = 0);
+    explicit averageWaveFrontFilesDlg(const QStringList &list, SurfaceManager *sm, QWidget *parent = 0);
     ~averageWaveFrontFilesDlg();
     wavefront *average;
 signals:

--- a/batchigramwizard.cpp
+++ b/batchigramwizard.cpp
@@ -88,7 +88,7 @@ void batchIntro::eraseItem()
     }
 }
 
-void batchIntro::showContextMenu(const QPoint &pos)
+void batchIntro::showContextMenu(QPoint pos)
 {
     // Handle global position
     QPoint globalPos = filesList->mapToGlobal(pos);

--- a/batchigramwizard.cpp
+++ b/batchigramwizard.cpp
@@ -27,7 +27,7 @@ QString batchIgramWizard::reviewFileName;
 QCheckBox *batchIgramWizard::autoOutlineCenter = 0;
 QCheckBox *batchIgramWizard::autoOutlineOutside = 0;
 
-batchIgramWizard::batchIgramWizard(QStringList files, QWidget *parent, Qt::WindowFlags flags) :
+batchIgramWizard::batchIgramWizard(const QStringList &files, QWidget *parent, Qt::WindowFlags flags) :
     QWizard(parent, flags),
     ui(new Ui::batchIgramWizard)
 {
@@ -257,7 +257,7 @@ bool batchIntro::shouldFilterWavefront(double rms){
     return (filterWavefront && rms > filterRms);
 }
 
-void batchIgramWizard::addAstig(QString name, QPointF value){
+void batchIgramWizard::addAstig(const QString &name, QPointF value){
 
     introPage->astigPlot->addValue(name,value);
 }
@@ -267,7 +267,7 @@ void batchIgramWizard::progressValue(int min, int max, int value){
     introPage->pgrBar->setValue(value);
 }
 
-void batchIgramWizard::addRms(QString name, QPointF p){
+void batchIgramWizard::addRms(const QString &name, QPointF p){
     introPage->m_rmsPlot->addValue(name,p);
 }
 

--- a/batchigramwizard.h
+++ b/batchigramwizard.h
@@ -40,12 +40,12 @@ public:
 
     static QCheckBox *autoOutlineOutside;
     static QCheckBox *autoOutlineCenter;
-    explicit batchIgramWizard(QStringList files, QWidget *parent = 0 , Qt::WindowFlags flags = Qt::Widget);
+    explicit batchIgramWizard(const QStringList &files, QWidget *parent = 0 , Qt::WindowFlags flags = Qt::Widget);
     ~batchIgramWizard();
     void listReady(QStringList list);
 
-    void addAstig(QString name, QPointF value);
-    void addRms(QString name, QPointF p);
+    void addAstig(const QString &name, QPointF value);
+    void addRms(const QString &name, QPointF p);
     void progressValue(int min, int max, int value);
     void select(int n);
     void showPlots(bool flags);

--- a/batchigramwizard.h
+++ b/batchigramwizard.h
@@ -82,7 +82,7 @@ class batchIntro : public QWizardPage
 public slots:
     void processBatch();
     void addFiles();
-    void showContextMenu(const QPoint &pos);
+    void showContextMenu(QPoint pos);
     void eraseItem();
     void showPlots(bool flags);
     void on_filter(bool);

--- a/camcalibrationreviewdlg.cpp
+++ b/camcalibrationreviewdlg.cpp
@@ -1,8 +1,8 @@
 #include "camcalibrationreviewdlg.h"
 #include "ui_camcalibrationreviewdlg.h"
 #include <QDebug>
-CamCalibrationReviewDlg::CamCalibrationReviewDlg(std::vector<cv::Mat> images, std::vector<cv::Mat> keypoints,
-                                                 std::vector<cv::Mat> corrected, QWidget *parent) :
+CamCalibrationReviewDlg::CamCalibrationReviewDlg(const std::vector<cv::Mat> &images, const std::vector<cv::Mat> &keypoints,
+                                                 const std::vector<cv::Mat> &corrected, QWidget *parent) :
     QDialog(parent),
     m_ndx(0), m_images(images), m_keypoints(keypoints), m_corrected(corrected),
     ui(new Ui::CamCalibrationReviewDlg), m_overlay(false), m_viewType(0)

--- a/camcalibrationreviewdlg.h
+++ b/camcalibrationreviewdlg.h
@@ -14,7 +14,7 @@ class CamCalibrationReviewDlg : public QDialog
     Q_OBJECT
 
 public:
-    explicit CamCalibrationReviewDlg(    std::vector<cv::Mat> images,    std::vector<cv::Mat> keypoints, std::vector<cv::Mat> corrected,QWidget *parent = 0);
+    explicit CamCalibrationReviewDlg(    const std::vector<cv::Mat> &images,    const std::vector<cv::Mat> &keypoints, const std::vector<cv::Mat> &corrected,QWidget *parent = 0);
     ~CamCalibrationReviewDlg();
     virtual void resizeEvent( QResizeEvent * );
 private slots:

--- a/camwizardpage1.cpp
+++ b/camwizardpage1.cpp
@@ -150,7 +150,7 @@ void CamWizardPage1::eraseItem()
     }
 }
 
-void CamWizardPage1::showContextMenu(const QPoint &pos)
+void CamWizardPage1::showContextMenu(QPoint pos)
 {
     // Handle global position
     QPoint globalPos = ui->listWidget->mapToGlobal(pos);

--- a/camwizardpage1.cpp
+++ b/camwizardpage1.cpp
@@ -108,7 +108,7 @@ double computeReprojectionErrors( const std::vector<std::vector<cv::Point3f> >& 
     return std::sqrt(totalErr/totalPoints);
 }
 bool CamWizardPage1::runCalibration( cv::Size& imageSize, cv::Mat& cameraMatrix, cv::Mat& distCoeffs,
-                            std::vector<std::vector<cv::Point2f> > imagePoints, std::vector<cv::Mat>& rvecs, std::vector<cv::Mat>& tvecs,
+                            const std::vector<std::vector<cv::Point2f> > &imagePoints, std::vector<cv::Mat>& rvecs, std::vector<cv::Mat>& tvecs,
                             std::vector<float>& reprojErrs,  double& totalAvgErr)
 {
 
@@ -162,7 +162,7 @@ void CamWizardPage1::showContextMenu(QPoint pos)
     myMenu.exec(globalPos);
 }
 
-bool CamWizardPage1::runCalibrationAndSave(cv::Size imageSize, cv::Mat&  cameraMatrix, cv::Mat& distCoeffs,std::vector<std::vector<cv::Point2f> > imagePoints )
+bool CamWizardPage1::runCalibrationAndSave(cv::Size imageSize, cv::Mat&  cameraMatrix, cv::Mat& distCoeffs,const std::vector<std::vector<cv::Point2f> > &imagePoints )
 {
     std::vector<cv::Mat> rvecs, tvecs;
     std::vector<float> reprojErrs;

--- a/camwizardpage1.h
+++ b/camwizardpage1.h
@@ -32,7 +32,7 @@ public:
 private slots:
     void on_compute_clicked();
     void on_pushButton_clicked();
-    void showContextMenu(const QPoint &pos);
+    void showContextMenu(QPoint pos);
     void eraseItem();
     void on_saveParams_clicked();
     void on_rows_valueChanged(int arg1);

--- a/camwizardpage1.h
+++ b/camwizardpage1.h
@@ -22,11 +22,11 @@ public:
     ~CamWizardPage1();
     QStringList fileList;
     bool runCalibration(cv::Size& imageSize, cv::Mat& cameraMatrix, cv::Mat& distCoeffs,
-                                std::vector<std::vector<cv::Point2f> > imagePoints, std::vector<cv::Mat>& rvecs, std::vector<cv::Mat>& tvecs,
+                                const std::vector<std::vector<cv::Point2f> > &imagePoints, std::vector<cv::Mat>& rvecs, std::vector<cv::Mat>& tvecs,
                                 std::vector<float>& reprojErrs,  double& totalAvgErr);
 
     bool runCalibrationAndSave(cv::Size imageSize, cv::Mat&  cameraMatrix,
-                                               cv::Mat& distCoeffs,std::vector<std::vector<cv::Point2f> > imagePoints );
+                                               cv::Mat& distCoeffs,const std::vector<std::vector<cv::Point2f> > &imagePoints );
     Ui::CamWizardPage1 *ui;
     cv::Mat m_coeffs;
 private slots:

--- a/colorchanneldisplay.cpp
+++ b/colorchanneldisplay.cpp
@@ -34,7 +34,7 @@ ColorChannelDisplay::~ColorChannelDisplay()
 {
     delete ui;
 }
-void ColorChannelDisplay::setImage(cv::Mat imgMat){
+void ColorChannelDisplay::setImage(const cv::Mat &imgMat){
 
     for (int channel = 0; channel < 3; ++channel){
         cv::Mat planes[4];

--- a/colorchanneldisplay.h
+++ b/colorchanneldisplay.h
@@ -33,7 +33,7 @@ class ColorChannelDisplay : public QDialog
 public:
     explicit ColorChannelDisplay(QWidget *parent = 0);
     ~ColorChannelDisplay();
-    void setImage(cv::Mat imgMat);
+    void setImage(const cv::Mat &imgMat);
 
 private:
     Ui::ColorChannelDisplay *ui;

--- a/colormapviewerdlg.cpp
+++ b/colormapviewerdlg.cpp
@@ -45,7 +45,7 @@ colorMapViewerDlg::colorMapViewerDlg(QWidget *parent) :
 
 }
 
-void colorMapViewerDlg::genList(QString path){
+void colorMapViewerDlg::genList(const QString &path){
     QStringList nameFilter("*.cmp");
     QDir directory(path);
     QStringList cmpFiles = directory.entryList(nameFilter);

--- a/colormapviewerdlg.h
+++ b/colormapviewerdlg.h
@@ -34,7 +34,7 @@ public:
     ~colorMapViewerDlg();
     QString m_selection;
 
-void genList(QString path);
+void genList(const QString &path);
 private slots:
     void on_browsePb_clicked();
 

--- a/contourplot.cpp
+++ b/contourplot.cpp
@@ -378,7 +378,7 @@ void ContourPlot::ruler(){
     }
 }
 
-void ContourPlot::selected(const QPointF& pos){
+void ContourPlot::selected(QPointF pos){
     if (m_wf==0)
         return;
 

--- a/contourplot.h
+++ b/contourplot.h
@@ -86,10 +86,10 @@ signals:
     void setMinMaxValues(double,double);
     void setWaveRange(double);
     void newContourRange(double);
-    void sigPointSelected(const QPointF&);
+    void sigPointSelected(QPointF );
 
 public Q_SLOTS:
-  void selected(const QPointF& pos);
+  void selected(QPointF pos);
 
 
 public Q_SLOTS:

--- a/contourview.cpp
+++ b/contourview.cpp
@@ -68,7 +68,7 @@ void contourView::setSurface(wavefront *wf){
     ps->setData(wf);
 }
 
-void contourView::showContextMenu(const QPoint &pos)
+void contourView::showContextMenu(QPoint pos)
 {
     // Handle global position
     QPoint globalPos = mapToGlobal(pos);

--- a/contourview.h
+++ b/contourview.h
@@ -44,7 +44,7 @@ signals:
     void zoomMe(bool);
 private slots:
     void on_doubleSpinBox_valueChanged(double arg1);
-    void showContextMenu(const QPoint &pos);
+    void showContextMenu(QPoint pos);
     void on_pushButton_pressed();
     void zoom();
 

--- a/counterrotationdlg.cpp
+++ b/counterrotationdlg.cpp
@@ -18,7 +18,7 @@
 #include "counterrotationdlg.h"
 #include "ui_counterrotationdlg.h"
 
-CounterRotationDlg::CounterRotationDlg(QString fn, double rot, bool dir, QWidget *parent) :
+CounterRotationDlg::CounterRotationDlg(const QString &fn, double rot, bool dir, QWidget *parent) :
     QDialog(parent),
     ui(new Ui::CounterRotationDlg)
 {

--- a/counterrotationdlg.h
+++ b/counterrotationdlg.h
@@ -29,7 +29,7 @@ class CounterRotationDlg : public QDialog
     Q_OBJECT
 
 public:
-    explicit CounterRotationDlg( QString fn, double rot, bool dir, QWidget *parent = 0);
+    explicit CounterRotationDlg( const QString &fn, double rot, bool dir, QWidget *parent = 0);
     ~CounterRotationDlg();
     QString getRotation();
     void setCCW(bool);

--- a/dftarea.cpp
+++ b/dftarea.cpp
@@ -544,7 +544,7 @@ void DFTArea::paintEvent(QPaintEvent *)
 double *g_qmap;
 class comp_qual {
 public:
-  int operator() (const int &p1, const int &p2) {
+  int operator() (int p1, int p2) {
     return (g_qmap[p1] < g_qmap[p2]);
   }
 };

--- a/dftarea.cpp
+++ b/dftarea.cpp
@@ -33,7 +33,7 @@
 using namespace cv;
 
 
-cv::Mat  makeMask(CircleOutline outside, CircleOutline center, cv::Mat data,
+cv::Mat  makeMask(const CircleOutline &outside, const CircleOutline &center, const cv::Mat &data,
                   QVector<std::vector<cv::Point> > poly){
     int width = data.cols;
     int height = data.rows;
@@ -389,7 +389,7 @@ void shiftDFT(cv::Mat &magI){
     tmp.copyTo(q2);
 }
 
-void showData(const std::string& txt, cv::Mat mat, bool useLog){
+void showData(const std::string& txt, const cv::Mat &mat, bool useLog){
 
     cv::Mat tmp = mat.clone();
     if (useLog){
@@ -405,7 +405,7 @@ void showData(const std::string& txt, cv::Mat mat, bool useLog){
 }
 
 
-QImage  showMag(cv::Mat complexI, bool show, const char* title, bool doLog, double gamma){
+QImage  showMag(const cv::Mat &complexI, bool show, const char* title, bool doLog, double gamma){
     // compute the magnitude and switch to logarithmic scale
     // => log(1 + sqrt(Re(DFT(I))^2 + Im(DFT(I))^2))
     Mat planes[2];
@@ -1053,7 +1053,7 @@ void DFTArea::makeSurface(){
     QApplication::restoreOverrideCursor();
     success = true;
 }
-void DFTArea::newIgram(QImage){
+void DFTArea::newIgram(const QImage&){
     doDFT();
 }
 void DFTArea::mouseReleaseEvent(QMouseEvent *)
@@ -1110,7 +1110,7 @@ void DFTArea::showResizedDlg(){
     }
 }
 
-void dumpMat(cv::Mat m, QString title = ""){
+void dumpMat(cv::Mat m, const QString &title = ""){
     qDebug() << "\r" << title << m.rows <<"X" << m.cols;
     for (int r = 0; r < m.rows; ++r){
         QString msg;
@@ -1347,7 +1347,7 @@ arma::mat zpmCxx(double rho, double theta, int maxorder) {
 }
 
 #include "outlinedialog.h"
-void DFTArea::doPSIstep4(cv::Mat images, QVector<double> phases){
+void DFTArea::doPSIstep4(const cv::Mat &images, QVector<double> phases){
 
     emit statusBarUpdate("computing surface from  interferograms.",1);
     m_outlineComplete = false;

--- a/dftarea.h
+++ b/dftarea.h
@@ -29,8 +29,8 @@
 #include "psi_dlg.h"
 #include "psiphasedisplay.h"
 
-extern void showData(const std::string& txt, cv::Mat mat, bool useLog = false);
-extern QImage showMag(cv::Mat complexI, bool show = false, const char *title = "FFT", bool doLog = true, double gamma = 0);
+extern void showData(const std::string& txt, const cv::Mat &mat, bool useLog = false);
+extern QImage showMag(const cv::Mat &complexI, bool show = false, const char *title = "FFT", bool doLog = true, double gamma = 0);
 extern void shiftDFT(cv::Mat &magI);
 
 
@@ -67,7 +67,7 @@ public slots:
     void doPSIstep1();
     bool doPSIstep2();
     void doPSIstep3();
-    void doPSIstep4(cv::Mat images, QVector<double> phases);
+    void doPSIstep4(const cv::Mat &images, QVector<double> phases);
     void doPSITilt();
     void doDFT();
     void dftSizeChanged(const QString&);
@@ -75,7 +75,7 @@ public slots:
     void setChannel(const QString&);
     void dftCenterFilter(double v);
     void makeSurface();
-    void newIgram(QImage);
+    void newIgram(const QImage&);
     void gamma(int);
     void showResizedDlg();
     void outlineDoneSig();

--- a/dftthumb.cpp
+++ b/dftthumb.cpp
@@ -27,7 +27,7 @@ dftThumb::dftThumb(QWidget *parent) :
     //ui->label->setSizePolicy( QSizePolicy::Ignored, QSizePolicy::Ignored );
 }
 
-void dftThumb::setImage(QImage img){
+void dftThumb::setImage(const QImage &img){
     m_img = img.scaled(300, 300, Qt::KeepAspectRatio);;
 
     ui->label->setPixmap(QPixmap::fromImage(m_img));//.scaled(labelSize, Qt::KeepAspectRatio)));

--- a/dftthumb.h
+++ b/dftthumb.h
@@ -31,7 +31,7 @@ class dftThumb : public QDialog
 public:
     explicit dftThumb(QWidget *parent = 0);
     ~dftThumb();
-void setImage(QImage img);
+void setImage(const QImage &img);
 private:
     Ui::dftThumb *ui;
     double scale;

--- a/dfttools.cpp
+++ b/dfttools.cpp
@@ -38,7 +38,7 @@ DFTTools::~DFTTools()
 {
     delete ui;
 }
-void DFTTools::imageSize(QString txt){
+void DFTTools::imageSize(const QString &txt){
     ui->imageSize->setText(txt);
 }
 

--- a/dfttools.h
+++ b/dfttools.h
@@ -32,7 +32,7 @@ public:
     explicit DFTTools(QWidget *parent = 0);
     void connectTo(QWidget *view);
     bool wasPressed;
-    void imageSize(QString txt);
+    void imageSize(const QString &txt);
     void setDFTSize(int val);
     ~DFTTools();
 signals:

--- a/foucaultview.cpp
+++ b/foucaultview.cpp
@@ -65,7 +65,7 @@ QString getSaveFileName(QString type){
     return fileName;
 
 }
-void foucaultView::showContextMenu(const QPoint &pos)
+void foucaultView::showContextMenu(QPoint pos)
 {
 
 // Handle global position

--- a/foucaultview.cpp
+++ b/foucaultview.cpp
@@ -52,7 +52,7 @@ foucaultView::~foucaultView()
     delete ui;
     spdlog::get("logger")->trace("foucaultView::~foucaultView");
 }
-QString getSaveFileName(QString type){
+QString getSaveFileName(const QString &type){
     QSettings settings;
     QString path = settings.value("lastPath","").toString();
 

--- a/foucaultview.h
+++ b/foucaultview.h
@@ -28,7 +28,7 @@ public slots:
     QImage *render();
 
 private slots:
-    void showContextMenu(const QPoint &pos);
+    void showContextMenu(QPoint pos);
 
     void on_gammaSb_valueChanged(double arg1);
 

--- a/helpdlg.cpp
+++ b/helpdlg.cpp
@@ -29,6 +29,6 @@ HelpDlg::~HelpDlg()
 {
     delete ui;
 }
-void HelpDlg::setHelpText(QString txt){
+void HelpDlg::setHelpText(const QString &txt){
     ui->textEdit->setHtml(txt);
 }

--- a/helpdlg.h
+++ b/helpdlg.h
@@ -31,7 +31,7 @@ class HelpDlg : public QDialog
 
 public:
     explicit HelpDlg(QWidget *parent = 0);
-    void setHelpText(QString txt);
+    void setHelpText(const QString &txt);
     ~HelpDlg();
 
 private:

--- a/igramarea.cpp
+++ b/igramarea.cpp
@@ -55,7 +55,7 @@ void undoStack::clear() {
     m_redo.clear();
 }
 
-void undoStack::push(QImage img, CircleOutline outline){
+void undoStack::push(const QImage &img, const CircleOutline &outline){
     m_redo.clear();
     m_stack.push_back(outlinePair(img,outline));
 
@@ -81,7 +81,7 @@ double distance(QPointF p1, QPointF p2)
     return qSqrt((p1.x() - p2.x())*(p1.x() - p2.x()) + (p1.y() - p2.y())*(p1.y() - p2.y()));
 }
 
-QImage cvMatToImage(cv::Mat out){
+QImage cvMatToImage(const cv::Mat &out){
     return QImage((uchar*)out.data, out.cols, out.rows,out.step1() ,QImage::Format_RGB888).copy();
 }
 IgramArea::IgramArea(QWidget *parent, void *mw)
@@ -277,7 +277,7 @@ cv::Mat IgramArea::qImageToMat(QImage &img){
      return iMat;
 }
 
-cv::Mat IgramArea::igramToGray(cv::Mat roi){
+cv::Mat IgramArea::igramToGray(const cv::Mat &roi){
     // split image into three color planes
 
     cv::Mat planes[4];
@@ -321,7 +321,7 @@ cv::Mat IgramArea::igramToGray(cv::Mat roi){
     return gray;
 
 }
-cv::Mat toSobel(cv::Mat roi){
+cv::Mat toSobel(const cv::Mat &roi){
 
     /// Generate grad_x and grad_y
     cv::Mat grad_x, grad_y, grad;
@@ -345,7 +345,7 @@ cv::Mat toSobel(cv::Mat roi){
     //cv::waitKey(1);
     return grad;
 }
-cv::Point2d IgramArea::findBestCenterOutline(cv::Mat gray, int start, int end,int step, int *radius, bool useExisting){
+cv::Point2d IgramArea::findBestCenterOutline(const cv::Mat &gray, int start, int end,int step, int *radius, bool useExisting){
     double cx  = m_outside.m_center.x() * searchOutlineScale;
     double cy = m_outside.m_center.y() * searchOutlineScale;
 
@@ -436,7 +436,7 @@ cv::Point2d IgramArea::findBestCenterOutline(cv::Mat gray, int start, int end,in
 
     return bestc;
 }
-cv::Point2d IgramArea::findBestOutsideOutline(cv::Mat gray, int start, int end,int step, int *radius, int pass){
+cv::Point2d IgramArea::findBestOutsideOutline(const cv::Mat &gray, int start, int end,int step, int *radius, int pass){
     QSettings set;
     bool showDebug = set.value("DebugShowOutlining", false).toBool();
     double cx = gray.cols/2.;
@@ -2082,7 +2082,7 @@ void IgramArea::crop() {
     emit upateColorChannels(qImageToMat(igramColor));
 
 }
-void IgramArea::dftReady(QImage img){
+void IgramArea::dftReady(const QImage &img){
     m_dftThumb->setImage(img);
     m_dftThumb->show();
     QRect r = m_dftThumb->geometry();
@@ -2117,7 +2117,7 @@ void IgramArea::CenterOutlineActive(bool checked){
     update();
 }
 
-void IgramArea::loadOutlineFile(QString fileName){
+void IgramArea::loadOutlineFile(const QString &fileName){
     QFile loadFile(fileName);
 
     if (!loadFile.open(QIODevice::ReadOnly)) {
@@ -2172,7 +2172,7 @@ void IgramArea::loadOutlineFile(QString fileName){
     }
 }
 
-void IgramArea::loadOutlineFileOldV6(QString fileName){
+void IgramArea::loadOutlineFileOldV6(const QString &fileName){
     std::ifstream file(fileName.toStdString().c_str());
 
     std::ifstream::pos_type fsize = file.tellg();
@@ -2520,7 +2520,7 @@ void IgramArea::hideOutline(bool checked){
     m_hideOutlines = checked;
     drawBoundary();
 }
-void IgramArea::igramOutlineParmsChanged(outlineParms parms){
+void IgramArea::igramOutlineParmsChanged(const outlineParms &parms){
     edgePenWidth = parms.edgeW;
     centerPenWidth = parms.centerW;
     edgePenColor = parms.edgeC;

--- a/igramintensity.cpp
+++ b/igramintensity.cpp
@@ -35,7 +35,7 @@ igramIntensity::~igramIntensity()
 {
     delete ui;
 }
-void igramIntensity::setIgram(cv::Mat img){
+void igramIntensity::setIgram(const cv::Mat &img){
 
     ui->plot->setSurface(img);
 

--- a/igramintensity.h
+++ b/igramintensity.h
@@ -32,7 +32,7 @@ class igramIntensity : public QDialog
 public:
     explicit igramIntensity(QWidget *parent = 0);
     ~igramIntensity();
-    void setIgram(cv::Mat img);
+    void setIgram(const cv::Mat &img);
 private slots:
     void on_showRed_clicked(bool checked);
 

--- a/imagehisto.cpp
+++ b/imagehisto.cpp
@@ -71,7 +71,7 @@ static void updateBrightnessContrast( int /*arg*/, void* )
 
 
 
-imageHisto::imageHisto( Mat im)
+imageHisto::imageHisto( const Mat &im)
 {
     image = im;
     namedWindow("image", 0);

--- a/imagehisto.h
+++ b/imagehisto.h
@@ -23,7 +23,7 @@
 class imageHisto
 {
 public:
-    imageHisto(cv::Mat im);
+    imageHisto(const cv::Mat &im);
 
 };
 

--- a/intensityplot.cpp
+++ b/intensityplot.cpp
@@ -50,7 +50,7 @@ class iSurfaceData: public QwtSyntheticPointData
 public:
     cv::Mat m_plane;
     int m_rad;
-    iSurfaceData(cv::Mat plane):
+    iSurfaceData(const cv::Mat &plane):
         QwtSyntheticPointData( plane.cols ),
       m_plane(plane), m_rad(plane.cols/2)
     {
@@ -159,7 +159,7 @@ void intensityPlot::angleChanged(double a){
 
 
 
-void intensityPlot::setSurface(cv::Mat imgMat){
+void intensityPlot::setSurface(const cv::Mat &imgMat){
 
     m_img = imgMat;
     split(imgMat,planes);

--- a/intensityplot.h
+++ b/intensityplot.h
@@ -27,7 +27,7 @@ Q_OBJECT
 public:
     intensityPlot(QWidget *parent = NULL);
     virtual ~intensityPlot() {}
-    void setSurface(cv::Mat imgMat);
+    void setSurface(const cv::Mat &imgMat);
     virtual void resizeEvent( QResizeEvent * );
     void showRed(bool);
     void showBlue(bool);

--- a/jitteroutlinedlg.cpp
+++ b/jitteroutlinedlg.cpp
@@ -24,7 +24,7 @@ jitterOutlineDlg::~jitterOutlineDlg()
 {
     delete ui;
 }
-void jitterOutlineDlg::status(QString status){
+void jitterOutlineDlg::status(const QString &status){
     ui->status->setText(status);
 }
 

--- a/jitteroutlinedlg.h
+++ b/jitteroutlinedlg.h
@@ -23,7 +23,7 @@ public:
     int getStart();
     int getEnd();
     int getType();
-    void status(QString status);
+    void status(const QString &status);
 
 private slots:
 

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -625,7 +625,7 @@ void MainWindow::selectDftTab(){
     ui->tabWidget->setCurrentIndex(1);
 }
 
-void MainWindow::updateChannels(cv::Mat img){
+void MainWindow::updateChannels(const cv::Mat &img){
 
 
     if (m_showChannels){
@@ -738,7 +738,7 @@ void MainWindow::on_actionSave_Wavefront_triggered()
 {
     m_surfaceManager->SaveWavefronts(false);
 }
-void MainWindow::showMessage(QString msg, int id){
+void MainWindow::showMessage(const QString &msg, int id){
 
     switch(id){
     case 1:
@@ -807,7 +807,7 @@ void MainWindow::on_showChannels_clicked(bool checked)
     else
         m_colorChannels->close();
 }
-void MainWindow::imageSize(QString txt){
+void MainWindow::imageSize(const QString &txt){
     ui->igramSize->setText(txt);
 }
 
@@ -821,7 +821,7 @@ void MainWindow::on_showIntensity_clicked(bool checked)
     else
         m_intensityPlot->close();
 }
-void MainWindow::newMirrorDlgPath(QString path){
+void MainWindow::newMirrorDlgPath(const QString &path){
     QFileInfo info(path);
     QSettings settings;
     settings.setValue("lastPath",info.path());

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -294,7 +294,7 @@ void MainWindow::importIgram() {
 
 }
 
-int showmem(QString t);
+int showmem(const QString &t);
 void MainWindow::openWaveFrontonInit(QStringList args){
     QProgressDialog pd("    Loading wavefronts in progress.", "Cancel", 0, 100);
     pd.setRange(0, args.size());
@@ -1848,8 +1848,8 @@ void MainWindow::on_actionCreate_Movie_of_wavefronts_triggered()
 arma::mat zapm(const arma::vec& rho, const arma::vec& theta,
                const double& eps, const int& maxorder=12) ;
 #include "armadillo"
-void dumpArma(arma::mat mm, QString title = "", QVector<QString> colHeading = QVector<QString>(0),
-              QVector<QString> RowLable = QVector<QString>(0));
+void dumpArma(const arma::mat &mm, const QString &title = "", QVector<QString> colHeading = QVector<QString>(0),
+              QVector<QString> RowLable = QVector<QString>(0)); //TODO move declaration to header
 void MainWindow::on_actionDebugStuff_triggered()
 {
     zernikeProcess *zp = zernikeProcess::get_Instance();

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -157,7 +157,7 @@ MainWindow::MainWindow(QWidget *parent) :
     m_profilePlot =  new ProfilePlot(review->s2,m_contourTools);
     connect(m_profilePlot, SIGNAL(zoomMe(bool)), this, SLOT(zoomProfile(bool)));
     connect(m_profilePlot, SIGNAL(profileAngleChanged(double)), m_contourView->getPlot(), SLOT(drawProfileLine(double)));
-    connect(m_contourView->getPlot()    , SIGNAL(sigPointSelected(const QPointF&)), m_profilePlot, SLOT(contourPointSelected(const QPointF&)));
+    connect(m_contourView->getPlot()    , SIGNAL(sigPointSelected(QPointF)), m_profilePlot, SLOT(contourPointSelected(QPointF)));
     m_mirrorDlg = mirrorDlg::get_Instance();
     review->s2->addWidget(review->s1);
     review->s2->addWidget(m_profilePlot);

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -82,7 +82,7 @@ public:
 
 public slots:
     void enableShiftButtons(bool enable);
-    void showMessage(QString, int id);
+    void showMessage(const QString&, int id);
     void diameterChanged(double);
     void rocChanged(double);
     void batchProcess(QStringList fileList);
@@ -97,7 +97,7 @@ public slots:
     void zoomContour(bool flag);
     void zoomOgl();
     void zoomProfile(bool flag);
-    void imageSize(QString txt);
+    void imageSize(const QString &txt);
     void skipBatchItem();
     int  getCurrentTab();
     void setTab(int ndx);
@@ -107,7 +107,7 @@ signals:
     void messageResult(int);
     void gammaChanged(bool, double);
 private slots:
-    void updateChannels(cv::Mat);
+    void updateChannels(const cv::Mat&);
     void openRecentFile();
     void on_actionLoad_Interferogram_triggered();
     void on_pushButton_5_clicked();
@@ -119,7 +119,7 @@ private slots:
     void on_shiftDown_clicked();
     void on_shiftRight_clicked();
     void selectDftTab();
-    void newMirrorDlgPath(QString path);
+    void newMirrorDlgPath(const QString &path);
     void on_actionRead_WaveFront_triggered();
 
     void on_actionPreferences_triggered();

--- a/metricsdisplay.cpp
+++ b/metricsdisplay.cpp
@@ -119,6 +119,6 @@ void metricsDisplay::on_sphericalPb_pressed()
     }
     emit recomputeZerns();
 }
-void metricsDisplay::setZernTitle(QString title){
+void metricsDisplay::setZernTitle(const QString &title){
     ui->zernTitle->setText(title);
 }

--- a/metricsdisplay.h
+++ b/metricsdisplay.h
@@ -44,7 +44,7 @@ public:
     void setName(QString name);
     void setWavePerFringe(double val, double lambda);
     void setOutputLambda(double val);
-    void setZernTitle(QString title);
+    void setZernTitle(const QString &title);
 private:
     bool shouldEnableAll;
 public slots:

--- a/mirrordlg.cpp
+++ b/mirrordlg.cpp
@@ -143,7 +143,7 @@ double mirrorDlg::getMinorAxis(){
 bool mirrorDlg::isEllipse(){
     return m_outlineShape == ELLIPSE;
 }
-void mirrorDlg::saveJson(QString fileName){
+void mirrorDlg::saveJson(const QString &fileName){
     QJsonObject jDoc, jMirror,jIgram, jEllipse, jAnnulus;
     jDoc["name"] = m_name;
     jDoc["show units in mm"] = mm;
@@ -598,7 +598,7 @@ void mirrorDlg::on_obs_textChanged(const QString &arg1)
     obs = ((mm) ? 1: 25.4) * arg1.toDouble();
 
 }
-void mirrorDlg::newLambda(QString v){
+void mirrorDlg::newLambda(const QString &v){
     ui->lambda->setText(v);
 }
 

--- a/mirrordlg.h
+++ b/mirrordlg.h
@@ -62,7 +62,7 @@ public:
     bool shouldFlipH();
     static QString getProjectPath();
     bool m_obsChanged;
-    void newLambda(QString v);
+    void newLambda(const QString &v);
     double getMinorAxis();
     bool m_majorHorizontal;
     double m_verticalAxis;
@@ -136,7 +136,7 @@ private:
     Ui::mirrorDlg *ui;
     bool m_aperatureReductionValueChanged;
     QTimer spacingChangeTimer;
-    void saveJson(QString fileName);
+    void saveJson(const QString &fileName);
     void enableAnnular(bool enable);
 };
 

--- a/myplotpicker.cpp
+++ b/myplotpicker.cpp
@@ -55,13 +55,13 @@ bool myPlotPicker::eventFilter( QObject *object, QEvent *event )
     return QObject::eventFilter( object, event );
 }
 
-void myPlotPicker::select(const QPointF &p){
+void myPlotPicker::select(QPointF p){
     QString s = find(p);
     if (s == "")
         return;
     emit mySelected(s);
 }
-QString myPlotPicker::find(const QPointF &p)const{
+QString myPlotPicker::find(QPointF p)const{
 
     QString s("");
     const QwtScaleMap xMap = m_plot->canvasMap(2);

--- a/myplotpicker.h
+++ b/myplotpicker.h
@@ -18,7 +18,7 @@ public:
     QString find(QPointF p)const;
     QwtPlot *m_plot;
 signals:
-    void mySelected(const QString);
+    void mySelected(const QString&);
 public slots:
 };
 

--- a/myplotpicker.h
+++ b/myplotpicker.h
@@ -14,8 +14,8 @@ public:
     explicit myPlotPicker( QwtPlot * plot);
     bool eventFilter( QObject *, QEvent * );
     virtual QwtText trackerTextF( const QPointF &pos ) const;
-    void select(const QPointF &p);
-    QString find(const QPointF &p)const;
+    void select(QPointF p);
+    QString find(QPointF p)const;
     QwtPlot *m_plot;
 signals:
     void mySelected(const QString);

--- a/nullvariationdlg.cpp
+++ b/nullvariationdlg.cpp
@@ -95,12 +95,12 @@ void nullVariationDlg::on_useMm_clicked(bool checked)
     on_useInch_clicked(!checked);
 }
 
-void nullVariationDlg::on_roc_textChanged(const QString )
+void nullVariationDlg::on_roc_textChanged(const QString &)
 {
         calculate();
 }
 
-void nullVariationDlg::on_diameter_textChanged(const QString)
+void nullVariationDlg::on_diameter_textChanged(const QString&)
 {
     calculate();
 }
@@ -120,7 +120,7 @@ void nullVariationDlg::on_diameterDelta_valueChanged(double val)
 }
 #include <qmap.h>
 #include <qwt_plot_histogram.h>
-QMap<double,int > histo(const QList<double> data, int bins){
+QMap<double,int > histo(const QList<double> &data, int bins){
     auto minma = std::minmax_element( data.begin(), data.end());
     double range = *minma.second - *minma.first;
     double histInterval = range/bins;

--- a/nullvariationdlg.h
+++ b/nullvariationdlg.h
@@ -25,9 +25,9 @@ private slots:
 
     void on_useMm_clicked(bool checked);
 
-    void on_roc_textChanged(const QString);
+    void on_roc_textChanged(const QString&);
 
-    void on_diameter_textChanged(const QString );
+    void on_diameter_textChanged(const QString &);
 
     void on_rocDelta_valueChanged(double val);
 

--- a/oglview.cpp
+++ b/oglview.cpp
@@ -105,7 +105,7 @@ OGLView::~OGLView(){
     delete m_surface;
 }
 
-void OGLView::showContextMenu(const QPoint &pos)
+void OGLView::showContextMenu(QPoint pos)
 {
     // Handle global position
     QPoint globalPos = mapToGlobal(pos);

--- a/oglview.h
+++ b/oglview.h
@@ -56,7 +56,7 @@ public slots:
     void saveImage();
     void showSelected();
     void enableFullScreen();
-    void showContextMenu(const QPoint &pos);
+    void showContextMenu(QPoint pos);
 
 };
 

--- a/outlinedialog.cpp
+++ b/outlinedialog.cpp
@@ -100,7 +100,7 @@ outlineDialog::~outlineDialog()
 }
 
 
-void outlineDialog::updateDisplay(cv::Mat img){
+void outlineDialog::updateDisplay(const cv::Mat &img){
 
     QImage tmp = QImage((uchar*)img.data,
                         img.cols,
@@ -112,7 +112,7 @@ void outlineDialog::updateDisplay(cv::Mat img){
                                                                                   Qt::KeepAspectRatio));
 }
 
-void outlineDialog::setImage(cv::Mat img){
+void outlineDialog::setImage(const cv::Mat &img){
     cv::Mat tmp;
     img.convertTo(tmp, CV_8UC1);
     cv::cvtColor(tmp,m_igram, cv::COLOR_GRAY2RGB);

--- a/outlinedialog.h
+++ b/outlinedialog.h
@@ -27,9 +27,9 @@ public:
     ~outlineDialog();
     double m_x, m_y, m_rad;
     cv::Mat img;
-    void setImage(cv::Mat img);
+    void setImage(const cv::Mat &img);
     void updateOutline();
-    void updateDisplay(cv::Mat img);
+    void updateDisplay(const cv::Mat &img);
 
 
 private slots:

--- a/outlinestatsdlg.cpp
+++ b/outlinestatsdlg.cpp
@@ -97,7 +97,7 @@ QVector<int> radiusHisto(const QVector<double>& dataQVect, double *minRad, int &
     return h;
 }
 
-outlineStatsDlg::outlineStatsDlg(QStringList names, QWidget *parent) :
+outlineStatsDlg::outlineStatsDlg(const QStringList &names, QWidget *parent) :
     QDialog(parent), m_names(names),
     ui(new Ui::outlineStatsDlg)
 {

--- a/outlinestatsdlg.h
+++ b/outlinestatsdlg.h
@@ -13,7 +13,7 @@ class outlineStatsDlg : public QDialog
     Q_OBJECT
 
 public:
-    explicit outlineStatsDlg(QStringList names, QWidget *parent = 0);
+    explicit outlineStatsDlg(const QStringList &names, QWidget *parent = 0);
     ~outlineStatsDlg();
     QStringList m_names;
     QVector<double> xvals;

--- a/percentCorrectionSurface.h
+++ b/percentCorrectionSurface.h
@@ -10,7 +10,7 @@ class surfaceData {
     std::vector<double> zernvalues;
     QString m_name;
 
-    surfaceData( double igramlambda, QColor pen, std::vector<double> zernvalues, QString name): igramlambda(igramlambda),
+    surfaceData( double igramlambda, QColor pen, const std::vector<double> &zernvalues, const QString &name): igramlambda(igramlambda),
         penColor(pen), zernvalues(zernvalues){ m_name = name;};
 } ;
 #endif // PERCENTCORRECTIONSURFACE_H

--- a/percentcorrectiondlg.cpp
+++ b/percentcorrectiondlg.cpp
@@ -162,7 +162,7 @@ void percentCorrectionDlg::updateZoneTable(){
     ui->percentTable->setColumnCount(m_zoneCenters.size());
     ui->percentTable->blockSignals(false);
 }
-QJsonDocument percentCorrectionDlg::loadZonesFromJson(QString str){
+QJsonDocument percentCorrectionDlg::loadZonesFromJson(const QString &str){
     QJsonParseError jsonError;
     QJsonDocument jsonDoc = QJsonDocument::fromJson(str.toUtf8(), &jsonError);
     QJsonObject jsonData=jsonDoc.object();
@@ -284,13 +284,13 @@ double percentCorrectionDlg::getZernSurface( double RoC, double /*MirrorRad*/, s
 }
 
 // profile from profile plot with null removed
-void percentCorrectionDlg::setProfile(QPolygonF profile){
+void percentCorrectionDlg::setProfile(const QPolygonF &profile){
     m_avg = profile;
 
 }
 // will use zernike values to compute two surface points x+- .01x  away from x
 //      then compute normal slope from that.
-double percentCorrectionDlg::getnormalSlope(double RoC, double radius, std::vector<double> Zernikes, double x, double null = 0, bool useAvg = false){
+double percentCorrectionDlg::getnormalSlope(double RoC, double radius, const std::vector<double> &Zernikes, double x, double null = 0, bool useAvg = false){
 
     double num1 = x / 100.0;
     double surface1 = getZernSurface(RoC, radius, Zernikes, x - num1, null,useAvg);  // problem  with zonendx  (the delta is not same as zonendx)
@@ -304,7 +304,7 @@ double percentCorrectionDlg::getnormalSlope(double RoC, double radius, std::vect
 // y = mx + b
 // b = y - mx
 
-double percentCorrectionDlg::GetActualKE(double RoC, double MirrorRad, std::vector<double> Zernikes, double x, double null, bool use_avg)
+double percentCorrectionDlg::GetActualKE(double RoC, double MirrorRad, const std::vector<double> &Zernikes, double x, double null, bool use_avg)
 {
 
     double slope = getnormalSlope(RoC, MirrorRad, Zernikes, x, null, use_avg);

--- a/percentcorrectiondlg.h
+++ b/percentcorrectiondlg.h
@@ -49,7 +49,7 @@ class percentCorrectionDlg : public QDialog
     QVector<surfaceData *>  surfs;
     QPolygonF makePercentages(surfaceData *);
 
-    double getnormalSlope(double RoC, double radius, std::vector<double> Zernikes, double x, double null, bool use_avg);
+    double getnormalSlope(double RoC, double radius, const std::vector<double> &Zernikes, double x, double null, bool use_avg);
     double getZernSurface( double RoC, double MirrorRad, std::vector<double> Zernikes, double x,
                            double null, bool useavg);
     double GetActualKE(double RoC, double MirrorRad, std::vector<double> Zernikes, double x);
@@ -73,13 +73,13 @@ public:
     ~percentCorrectionDlg();
     std::vector<double> m_zerns;
     void setData(QVector< surfaceData *> );
-    void setProfile(QPolygonF profile);
+    void setProfile(const QPolygonF &profile);
     void plot();
     void plotProfile();
     void plotSlope();
     void updateZoneTable();
-    QJsonDocument loadZonesFromJson(QString str);
-    double GetActualKE(double RoC, double MirrorRad, std::vector<double> Zernikes,  double x, double nulll, bool use_avg);
+    QJsonDocument loadZonesFromJson(const QString &str);
+    double GetActualKE(double RoC, double MirrorRad, const std::vector<double> &Zernikes,  double x, double nulll, bool use_avg);
     QList<double> generateZoneCenters(double radius, int number_of_zones, bool makenew = true);
 private slots:
     void on_percentTable_itemChanged(QTableWidgetItem *item);

--- a/pixelstats.cpp
+++ b/pixelstats.cpp
@@ -124,7 +124,7 @@ bool CanvasPicker::eventFilter( QObject *object, QEvent *event )
 // Select the point at a position. If there is no point
 // deselect the selected point
 
-void CanvasPicker::select( const QPoint &pos )
+void CanvasPicker::select( QPoint pos )
 {
     QwtPlotMarker *mark = NULL;
     double dist = 10e10;
@@ -180,7 +180,7 @@ void CanvasPicker::select( const QPoint &pos )
 
 
 // Move the selected point
-void CanvasPicker::move( const QPoint &pos )
+void CanvasPicker::move( QPoint pos )
 {
     if ( !d_selectedMarker )
         return;

--- a/pixelstats.h
+++ b/pixelstats.h
@@ -56,8 +56,8 @@ Q_SIGNALS:
     void markerMoved();
 
 private:
-    void select( const QPoint & );
-    void move( const QPoint & );
+    void select( QPoint  );
+    void move( QPoint  );
     void release();
 
     void shiftCurveCursor();

--- a/profileplot.cpp
+++ b/profileplot.cpp
@@ -757,7 +757,7 @@ void ProfilePlot::zoom(){
     emit zoomMe(zoomed);
 }
 
-void ProfilePlot::showContextMenu(const QPoint &pos)
+void ProfilePlot::showContextMenu(QPoint pos)
 {
     // Handle global position
     QPoint globalPos = mapToGlobal(pos);
@@ -783,7 +783,7 @@ void ProfilePlot::resizeEvent( QResizeEvent *)
         wfs = wf;
     }
 
-void ProfilePlot::contourPointSelected(const QPointF &pos){
+void ProfilePlot::contourPointSelected(QPointF pos){
     if (m_wf == 0)
         return;
     double delx = pos.x() - m_wf->data.rows/2;

--- a/profileplot.cpp
+++ b/profileplot.cpp
@@ -253,7 +253,7 @@ void ProfilePlot::showAll(){
     populate();
     m_plot->replot();
 }
-void ProfilePlot::zeroOffsetChanged(QString s){
+void ProfilePlot::zeroOffsetChanged(const QString &s){
     if (offsetType == s)
         return;
     double mul = m_showNm * m_showSurface;
@@ -318,7 +318,7 @@ void ProfilePlot::setSurface(wavefront * wf){
     m_plot->replot();
 }
 
-void ProfilePlot::setDefocusWaveFront( cv::Mat_<double> wf){
+void ProfilePlot::setDefocusWaveFront( const cv::Mat_<double> &wf){
     m_defocus_wavefront = wf.clone();
 }
 

--- a/profileplot.h
+++ b/profileplot.h
@@ -64,7 +64,7 @@ public:
 
     double slopeLimitArcSec;
     void setDefocusValue(double val);
-    void setDefocusWaveFront( cv::Mat_<double> wf);
+    void setDefocusWaveFront( const cv::Mat_<double> &wf);
 signals:
     void zoomMe(bool);
     void profileAngleChanged(const double ang);
@@ -74,7 +74,7 @@ public slots:
     void setWavefronts(QVector<wavefront*> *wf);
     void angleChanged(double a);
     void newDisplayErrorRange(double min, double max);
-    void zeroOffsetChanged(QString);
+    void zeroOffsetChanged(const QString&);
     void showOne();
     void show16();
     void showAll();

--- a/profileplot.h
+++ b/profileplot.h
@@ -81,10 +81,10 @@ public slots:
     void showNm(bool);
     void showSurface(bool);
     void zoom();
-    void showContextMenu(const QPoint &pos);
+    void showContextMenu(QPoint pos);
     void showSlope(bool);
     void slopeLimit(double);
-    void contourPointSelected(const QPointF &pos);
+    void contourPointSelected(QPointF pos);
     void populate();
     void showCorrection();
     void make_correction_graph();

--- a/profileplotpicker.cpp
+++ b/profileplotpicker.cpp
@@ -97,7 +97,7 @@ bool profilePlotPicker::eventFilter( QObject *object, QEvent *event )
 // Select the point at a position. If there is no point
 // deselect the selected point
 
-void profilePlotPicker::select( const QPoint &pos )
+void profilePlotPicker::select( QPoint pos )
 {
     QwtPlotCurve *curve = NULL;
     double dist = 10e10;
@@ -129,7 +129,7 @@ void profilePlotPicker::select( const QPoint &pos )
 
 
 // Move the selected point
-void profilePlotPicker::move( const QPoint &pos )
+void profilePlotPicker::move( QPoint pos )
 {
     qDebug() << "move pos" << pos;
     if ( !d_selectedCurve )

--- a/profileplotpicker.h
+++ b/profileplotpicker.h
@@ -20,8 +20,8 @@ public:
 
 private:
 
-    void select( const QPoint & );
-    void move( const QPoint & );
+    void select( QPoint  );
+    void move( QPoint  );
     void moveBy( int dx, int dy );
 
     void release();

--- a/psfplot.cpp
+++ b/psfplot.cpp
@@ -55,7 +55,7 @@ void psfPlot::clear(){
 
 }
 
-void psfPlot::setData(cv::Mat wf, QString label, QPen color, bool doLog){
+void psfPlot::setData(cv::Mat wf, const QString &label, const QPen &color, bool doLog){
     int nx = wf.cols/2;
     QwtPlotCurve *curve1 = new QwtPlotCurve(label);
     QPolygonF points1;

--- a/psfplot.h
+++ b/psfplot.h
@@ -36,7 +36,7 @@ class psfPlot : public QwtPlot
 public:
     explicit psfPlot(QWidget *parent = 0);
     ~psfPlot();
-    void setData(cv::Mat wf, QString label, QPen color, bool doLog);
+    void setData(cv::Mat wf, const QString &label, const QPen &color, bool doLog);
     void clear();
 
 private:

--- a/psiphasedisplay.cpp
+++ b/psiphasedisplay.cpp
@@ -12,7 +12,7 @@
     #define M_PI 3.14159265358979323846
 #endif
 
-PSIphaseDisplay::PSIphaseDisplay(QVector<double> phases,QWidget *parent) :
+PSIphaseDisplay::PSIphaseDisplay(const QVector<double> &phases,QWidget *parent) :
     QDialog(parent),
     ui(new Ui::PSIphaseDisplay),m_useRadians(false)
 {
@@ -30,7 +30,7 @@ PSIphaseDisplay::~PSIphaseDisplay()
 void PSIphaseDisplay::useRadians(bool /*use*/){
     // TODO PSIphaseDisplay doesn't take into account m_useRadians from psi_dlg (JST 2023/07/11)
 }
-void PSIphaseDisplay::setPhases(QVector<double> phases, int iteration, double sdp){
+void PSIphaseDisplay::setPhases(const QVector<double> &phases, int iteration, double sdp){
     plot(phases, iteration, sdp);
 }
 void PSIphaseDisplay::plot(QVector<double> phases, int iteration, double sdp){

--- a/psiphasedisplay.h
+++ b/psiphasedisplay.h
@@ -13,9 +13,9 @@ class PSIphaseDisplay : public QDialog
     Q_OBJECT
 
 public:
-    explicit PSIphaseDisplay( QVector<double> phases, QWidget *parent = 0);
+    explicit PSIphaseDisplay( const QVector<double> &phases, QWidget *parent = 0);
     ~PSIphaseDisplay();
-    void setPhases(QVector<double> phases, int iteration, double sdp);
+    void setPhases(const QVector<double> &phases, int iteration, double sdp);
     void useRadians(bool use);
 private:
     Ui::PSIphaseDisplay *ui;

--- a/punwrap.cpp
+++ b/punwrap.cpp
@@ -275,7 +275,7 @@ class comp_qual
 {
 public:
 
-    int operator() (const qual &p1, const qual &p2)
+    int operator() (qual p1, qual p2)
     {
     return (p1.m_q < p2.m_q);
     }

--- a/regionedittools.cpp
+++ b/regionedittools.cpp
@@ -38,7 +38,7 @@ void regionEditTools::on_line_clicked(bool /*checked*/)
     m_doFreeform = false;
 }
 
-void regionEditTools::addRegion(QString text){
+void regionEditTools::addRegion(const QString &text){
     ui->listWidget->addItem(text);
 }
 

--- a/regionedittools.h
+++ b/regionedittools.h
@@ -17,7 +17,7 @@ public:
     bool m_doLine;
     bool m_doFreeform;
     int currentNdx;
-    void addRegion(QString text);
+    void addRegion(const QString &text);
     void deleteRegion(int r);
     void clear();
 signals:

--- a/rejectedwavefrontsdlg.cpp
+++ b/rejectedwavefrontsdlg.cpp
@@ -1,7 +1,7 @@
 #include "rejectedwavefrontsdlg.h"
 #include "ui_rejectedwavefrontsdlg.h"
 
-rejectedWavefrontsDlg::rejectedWavefrontsDlg(QStringList list, QWidget *parent) :
+rejectedWavefrontsDlg::rejectedWavefrontsDlg(const QStringList &list, QWidget *parent) :
     QDialog(parent),
     ui(new Ui::rejectedWavefrontsDlg)
 {

--- a/rejectedwavefrontsdlg.h
+++ b/rejectedwavefrontsdlg.h
@@ -12,7 +12,7 @@ class rejectedWavefrontsDlg : public QDialog
     Q_OBJECT
 
 public:
-    explicit rejectedWavefrontsDlg(QStringList list, QWidget *parent = 0);
+    explicit rejectedWavefrontsDlg(const QStringList &list, QWidget *parent = 0);
     ~rejectedWavefrontsDlg();
 
 private:

--- a/renamewavefrontdlg.cpp
+++ b/renamewavefrontdlg.cpp
@@ -18,7 +18,7 @@
 #include "renamewavefrontdlg.h"
 #include "ui_renamewavefrontdlg.h"
 
-renameWavefrontDlg::renameWavefrontDlg(QString name, QWidget *parent) :
+renameWavefrontDlg::renameWavefrontDlg(const QString &name, QWidget *parent) :
     QDialog(parent),
     ui(new Ui::renameWavefrontDlg)
 {

--- a/renamewavefrontdlg.h
+++ b/renamewavefrontdlg.h
@@ -29,7 +29,7 @@ class renameWavefrontDlg : public QDialog
     Q_OBJECT
 
 public:
-    explicit renameWavefrontDlg(QString name, QWidget *parent = 0);
+    explicit renameWavefrontDlg(const QString &name, QWidget *parent = 0);
     ~renameWavefrontDlg();
     QString name();
 

--- a/rmsplot.cpp
+++ b/rmsplot.cpp
@@ -34,10 +34,10 @@ rmsPlot::rmsPlot(QWidget *parent):QwtPlot( parent ),m_max(.3)
     m_max = 0;
     replot();
 }
-void rmsPlot::selectedwave(QString m){
+void rmsPlot::selectedwave(const QString &m){
     emit waveSeleted(m);
 }
-void rmsPlot::addValue(QString name, QPointF p){
+void rmsPlot::addValue(const QString &name, QPointF p){
     QwtPlotMarker *m = new QwtPlotMarker(name);
     if (p.y() > m_max)
         m_max = p.y();

--- a/rmsplot.h
+++ b/rmsplot.h
@@ -21,9 +21,9 @@ public:
     explicit rmsPlot(QWidget *parent = 0);
 
 public:
-    void addValue(QString name, QPointF p);
+    void addValue(const QString &name, QPointF p);
 private slots:
-    void selectedwave(QString m);
+    void selectedwave(const QString &m);
 signals:
     void waveSeleted(QString);
 };

--- a/rotationdlg.cpp
+++ b/rotationdlg.cpp
@@ -20,7 +20,7 @@
 #include <opencv2/opencv.hpp>
 #include <qsettings.h>
 
-RotationDlg::RotationDlg( QList<int> list, QWidget *parent) :
+RotationDlg::RotationDlg( const QList<int> &list, QWidget *parent) :
     QDialog(parent),
     ui(new Ui::RotationDlg), list(list)
 {

--- a/rotationdlg.h
+++ b/rotationdlg.h
@@ -29,7 +29,7 @@ class RotationDlg : public QDialog
     Q_OBJECT
 
 public:
-    explicit RotationDlg( QList<int> list, QWidget *parent = 0);
+    explicit RotationDlg( const QList<int> &list, QWidget *parent = 0);
     ~RotationDlg();
 signals:
 

--- a/savewavedlg.cpp
+++ b/savewavedlg.cpp
@@ -18,7 +18,7 @@
 #include "savewavedlg.h"
 #include "ui_savewavedlg.h"
 #include <QFileDialog>
-SaveWaveDlg::SaveWaveDlg(QString lastPath, QWidget *parent) :
+SaveWaveDlg::SaveWaveDlg(const QString &lastPath, QWidget *parent) :
      QDialog(parent),lastPath(lastPath),
     ui(new Ui::SaveWaveDlg)
 {

--- a/savewavedlg.h
+++ b/savewavedlg.h
@@ -29,7 +29,7 @@ class SaveWaveDlg : public QDialog
     Q_OBJECT
 
 public:
-    explicit SaveWaveDlg(QString lastPath, QWidget *parent = 0);
+    explicit SaveWaveDlg(const QString &lastPath, QWidget *parent = 0);
     ~SaveWaveDlg();
     QString fileName;
     QString lastPath;

--- a/settingsigram.cpp
+++ b/settingsigram.cpp
@@ -184,7 +184,7 @@ void settingsIGram::eraseItem()
     lensesModel->removeRow(currentNdx.row());
     saveLensData();
 }
-void settingsIGram::showContextMenu(const QPoint &pos)
+void settingsIGram::showContextMenu(QPoint pos)
 {
     // Handle global position
     QPoint globalPos = ui->lenseTableView->mapToGlobal(pos);

--- a/settingsigram.cpp
+++ b/settingsigram.cpp
@@ -205,7 +205,7 @@ void settingsIGram::saveLensData(){
     set.setValue("Lenses", v.join("\n"));
 }
 
-void settingsIGram::updateLenses(QString str){
+void settingsIGram::updateLenses(const QString &str){
     m_lensData.push_back(str.split(","));
     saveLensData();
     lensesModel->insertRow(m_lensData.size() -2);

--- a/settingsigram.h
+++ b/settingsigram.h
@@ -48,7 +48,7 @@ public:
     bool m_removeDistortion;
     bool m_autoSaveOutline;
     QStringList m_lenseParms;
-    void updateLenses(QString str);
+    void updateLenses(const QString &str);
 signals:
     void igramLinesChanged(outlineParms);
 private slots:

--- a/settingsigram.h
+++ b/settingsigram.h
@@ -67,7 +67,7 @@ private slots:
 
     void eraseItem();
 
-    void showContextMenu(const QPoint &pos);
+    void showContextMenu(QPoint pos);
 
 
     void on_lenseTableView_clicked(const QModelIndex &index);

--- a/showaliasdlg.cpp
+++ b/showaliasdlg.cpp
@@ -39,7 +39,7 @@ class ImageViewer : public QWidget {
     }
 
 public:
-    void setImage(cv::Mat mat){
+    void setImage(const cv::Mat &mat){
         cv::Mat rgb;
         cv::cvtColor(mat,rgb, cv::COLOR_GRAY2RGB);
         QImage img= QImage((uchar*) rgb.data, rgb.cols, rgb.rows, rgb.step,

--- a/simigramdlg.cpp
+++ b/simigramdlg.cpp
@@ -205,7 +205,7 @@ simIgramDlg *simIgramDlg::get_instance(){
 double simIgramDlg::getObs(){
     return ui->obsPercent->value();
 }
-void simIgramDlg::setNewTerms(std::vector<double> terms){
+void simIgramDlg::setNewTerms(const std::vector<double> &terms){
 
     zernikes = terms;
     tableModel->setValues(&zernikes);

--- a/simigramdlg.h
+++ b/simigramdlg.h
@@ -69,7 +69,7 @@ public:
     bool doCorrection;
     std::vector<double> zernikes;
     std::vector<bool> enables;
-    void setNewTerms(std::vector<double> terms);
+    void setNewTerms(const std::vector<double> &terms);
 
     double getObs();
     bool m_doEdge;

--- a/simulationsview.cpp
+++ b/simulationsview.cpp
@@ -455,7 +455,7 @@ void etoxplusy(cv::Mat data)
         }
     }
 }
-void SimulationsView::mtf(cv::Mat star, QString txt, QColor color){
+void SimulationsView::mtf(const cv::Mat &star, const QString &txt, QColor color){
     cv::Mat planes[2];
     cv::Mat mtfIn, mtfOut, mtfMag;
     split(star,planes);
@@ -517,7 +517,7 @@ int stalkWidth;
 #include <opencv2/highgui/highgui.hpp>
 #include <opencv2/imgproc.hpp>
 using namespace cv;
-cv::Mat make_obstructionMask(cv::Mat mask){
+cv::Mat make_obstructionMask(const cv::Mat &mask){
     //return;
     cv::Mat out = mask.clone();
     int s = mask.size[0];
@@ -533,7 +533,7 @@ cv::Mat make_obstructionMask(cv::Mat mask){
 
 
 //3D psf
-void SimulationsView::make3DPsf(cv::Mat surface){
+void SimulationsView::make3DPsf(const cv::Mat &surface){
 
     int nx = surface.size[0];
     int start = nx/2 - nx/4;

--- a/simulationsview.cpp
+++ b/simulationsview.cpp
@@ -159,7 +159,7 @@ void SimulationsView::saveImage(QString fileName){
     svImage.save(fileName);
 }
 
-void SimulationsView::showContextMenu(const QPoint &pos)
+void SimulationsView::showContextMenu(QPoint pos)
 {
 
 // Handle global position

--- a/simulationsview.h
+++ b/simulationsview.h
@@ -76,7 +76,7 @@ private slots:
 
     void on_FFTSizeSB_valueChanged(int val);
 
-    void showContextMenu(const QPoint &pos);
+    void showContextMenu(QPoint pos);
 
     void saveImage(QString fn = "");
 

--- a/simulationsview.h
+++ b/simulationsview.h
@@ -60,10 +60,10 @@ private:
     double dX;  // pupil sample size based on mirror size in wave front.
     double dF;  // psf sample size;
 
-    void mtf(cv::Mat magPsf, QString txt, QColor color);
+    void mtf(const cv::Mat &magPsf, const QString &txt, QColor color);
     void initMTFPlot();
 
-    void make3DPsf(cv::Mat surface);
+    void make3DPsf(const cv::Mat &surface);
 public slots:
         void on_MakePB_clicked();
 private slots:

--- a/standastigwizard.cpp
+++ b/standastigwizard.cpp
@@ -168,7 +168,7 @@ void define_input::deleteSelected(){
 void define_input::changeRotation(){
 }
 
-void define_input::showContextMenu(const QPoint &pos)
+void define_input::showContextMenu(QPoint pos)
 {
     // Handle global position
     QPoint globalPos = listDisplay->mapToGlobal(pos);

--- a/standastigwizard.h
+++ b/standastigwizard.h
@@ -77,7 +77,7 @@ class rotationDef {
 public:
     QString fname;
     double angle;
-    rotationDef(QString name, double angle) :
+    rotationDef(const QString &name, double angle) :
         fname(name), angle(angle){};
 };
 

--- a/standastigwizard.h
+++ b/standastigwizard.h
@@ -119,7 +119,7 @@ private slots:
     void browse();
     void deleteSelected();
     void setBasePath();
-    void showContextMenu(const QPoint &pdos);
+    void showContextMenu(QPoint pdos);
     void changeRotation();
 signals:
     void computeStandAstig(define_input *,QList<rotationDef *>);

--- a/statsview.cpp
+++ b/statsview.cpp
@@ -216,7 +216,7 @@ void statsView::on_saveImg_clicked()
 
     image.save( fName, QFileInfo( fName ).suffix().toLatin1() );
 }
-QString statsView::title(QString dir){
+QString statsView::title(const QString &dir){
 
     QString title = m_sm->m_wavefronts[0]->name;
     title = title.left(title.lastIndexOf("/"));

--- a/statsview.h
+++ b/statsview.h
@@ -25,7 +25,7 @@ public:
     QWidget *w1,*w2,*w3;
     ~statsView();
     void replot();
-    QString title(QString dir);
+    QString title(const QString &dir);
     void getWavefronts();
     void sresize();
 

--- a/subtractwavefronatsdlg.cpp
+++ b/subtractwavefronatsdlg.cpp
@@ -18,7 +18,7 @@
 #include "subtractwavefronatsdlg.h"
 #include "ui_subtractwavefronatsdlg.h"
 
-subtractWavefronatsDlg::subtractWavefronatsDlg(QList<QString> list, QWidget *parent) :
+subtractWavefronatsDlg::subtractWavefronatsDlg(const QList<QString> &list, QWidget *parent) :
     QDialog(parent),
     ui(new Ui::subtractWavefronatsDlg)
 {

--- a/subtractwavefronatsdlg.h
+++ b/subtractwavefronatsdlg.h
@@ -29,7 +29,7 @@ class subtractWavefronatsDlg : public QDialog
     Q_OBJECT
 
 public:
-    explicit subtractWavefronatsDlg(QList<QString> list, QWidget *parent = 0);
+    explicit subtractWavefronatsDlg(const QList<QString> &list, QWidget *parent = 0);
     ~subtractWavefronatsDlg();
     int getSelected();
     bool use_null;

--- a/surfaceanalysistools.cpp
+++ b/surfaceanalysistools.cpp
@@ -156,7 +156,7 @@ void surfaceAnalysisTools::on_wavefrontList_clicked(const QModelIndex &index)
 }
 
 // this is "right click" on windows
-void surfaceAnalysisTools::on_wavefrontList_customContextMenuRequested(const QPoint &pos)
+void surfaceAnalysisTools::on_wavefrontList_customContextMenuRequested(QPoint pos)
 {
     QListWidgetItem *item = ui->wavefrontList->itemAt(pos);
     if (item == 0)

--- a/surfaceanalysistools.cpp
+++ b/surfaceanalysistools.cpp
@@ -66,7 +66,7 @@ void surfaceAnalysisTools::enableControls(bool flag){
 }
 
 
-void surfaceAnalysisTools::setBlurText(QString txt){
+void surfaceAnalysisTools::setBlurText(const QString &txt){
     ui->blurMm->setText(txt);
 }
 
@@ -243,11 +243,11 @@ void surfaceAnalysisTools::on_SelectNonePB_clicked()
 {
     ui->wavefrontList->selectionModel()->reset();
 }
-void surfaceAnalysisTools::nameChanged(int ndx, QString newname){
+void surfaceAnalysisTools::nameChanged(int ndx, const QString &newname){
     ui->wavefrontList->item(ndx)->setText(newname);
 }
 
-void surfaceAnalysisTools::nameChanged(QString old, QString newname){
+void surfaceAnalysisTools::nameChanged(const QString &old, const QString &newname){
 
     // first look for full length name match
     QList<QListWidgetItem *> ql = ui->wavefrontList->findItems(old,Qt::MatchExactly);

--- a/surfaceanalysistools.h
+++ b/surfaceanalysistools.h
@@ -47,8 +47,8 @@ public:
     bool m_useDefocus;
     double m_defocus;
     double m_defocusInmm;
-    void setBlurText(QString txt);
-    void nameChanged(int, QString);
+    void setBlurText(const QString &txt);
+    void nameChanged(int, const QString&);
     void select(int item);
 
 signals:
@@ -73,7 +73,7 @@ public slots:
     void currentNdxChanged(int);
     void deleteWaveFront(int);
     void defocusTimerDone();
-    void nameChanged(QString, QString);
+    void nameChanged(const QString&, const QString&);
     void defocusControlChanged(double);
     void enableControls(bool);
 private slots:

--- a/surfaceanalysistools.h
+++ b/surfaceanalysistools.h
@@ -83,7 +83,7 @@ private slots:
 
     void on_wavefrontList_activated(const QModelIndex &index);
     void on_wavefrontList_clicked(const QModelIndex &index);
-    void on_wavefrontList_customContextMenuRequested(const QPoint &pos);
+    void on_wavefrontList_customContextMenuRequested(QPoint pos);
 
     void on_blurCB_clicked(bool checked);
 

--- a/surfacemanager.cpp
+++ b/surfacemanager.cpp
@@ -3216,7 +3216,7 @@ void SurfaceManager::flipHorizontal(){
     }
     QApplication::restoreOverrideCursor();
 }
-bool QPointFLessThan(const QPointF &p1, const QPointF & p2){
+bool QPointFLessThan(QPointF p1, QPointF p2){
     return p1.x() < p2.x();
 }
 

--- a/surfacemanager.cpp
+++ b/surfacemanager.cpp
@@ -256,7 +256,7 @@ class wftNameScaleDraw: public QwtScaleDraw
 public:
     QVector<wavefront*> names;
     int currentNdx;
-    wftNameScaleDraw(QVector<wavefront*> nameList, int nx)
+    wftNameScaleDraw(const QVector<wavefront*> &nameList, int nx)
     {
         names = nameList;
         currentNdx = nx;
@@ -302,7 +302,7 @@ class ZernScaleDraw: public QwtScaleDraw
 {
 public:
     QVector<QString> m_names;
-    ZernScaleDraw(QVector<QString> names)
+    ZernScaleDraw(const QVector<QString> &names)
 
     {
         m_names = names;
@@ -686,7 +686,7 @@ void SurfaceManager::makeMask(wavefront *wf, bool useInsideCircle){
         showData("surface manager mask",mask);
 
 }
-void SurfaceManager::wftNameChanged(int ndx, QString name){
+void SurfaceManager::wftNameChanged(int ndx, const QString &name){
     m_wavefronts[ndx]->name = name;
 
 }
@@ -905,7 +905,7 @@ void SurfaceManager::computeZerns()
     m_waveFrontTimer->start(500);
 }
 
-void SurfaceManager::writeWavefront(QString fname, wavefront *wf, bool saveNulled){
+void SurfaceManager::writeWavefront(const QString &fname, wavefront *wf, bool saveNulled){
         std::ofstream file((fname.toStdString().c_str()));
 
         if (!file.is_open()) {
@@ -1029,7 +1029,7 @@ void SurfaceManager::SaveWavefronts(bool saveNulled){
 }
 void SurfaceManager::createSurfaceFromPhaseMap(cv::Mat phase, CircleOutline outside,
                                                CircleOutline center,
-                                               QString name, QVector<std::vector<cv::Point> > polyArea){
+                                               const QString &name, QVector<std::vector<cv::Point> > polyArea){
 
     wavefront *wf;
 
@@ -1087,7 +1087,7 @@ void SurfaceManager::createSurfaceFromPhaseMap(cv::Mat phase, CircleOutline outs
     emit showTab(2);
 }
 
-wavefront * SurfaceManager::readWaveFront(QString fileName){
+wavefront * SurfaceManager::readWaveFront(const QString &fileName){
     std::ifstream file(fileName.toStdString().c_str());
     if (!file) {
         QString b = "Can not read file " + fileName + " " +strerror(errno);
@@ -1383,7 +1383,7 @@ void SurfaceManager::previous(){
 
     sendSurface(m_wavefronts[m_currentNdx]);
 }
-QVector<int> histo(const std::vector<double> data, int bins, double min, double max){
+QVector<int> histo(const std::vector<double> &data, int bins, double min, double max){
     QVector<int> h(bins, 0);
     double interval = (max - min)/bins;
     for (unsigned int i = 0; i < data.size(); ++i){
@@ -1627,7 +1627,7 @@ void SurfaceManager::averageComplete(wavefront *wf){
     m_surfaceTools->select(m_currentNdx);
 }
 
-void SurfaceManager::averageWavefrontFiles(QStringList files){
+void SurfaceManager::averageWavefrontFiles(const QStringList &files){
     averageWaveFrontFilesDlg dlg(files, this);
     connect(&dlg, SIGNAL(averageComplete(wavefront*)), this, SLOT(averageComplete(wavefront *)));
     if (dlg.exec()){
@@ -1807,7 +1807,7 @@ void SurfaceManager::subtractWavefronts(){
     }
 }
 
-void SurfaceManager::transfrom(QList<int> list){
+void SurfaceManager::transfrom(const QList<int> &list){
     RotationDlg dlg(list);
     connect(&dlg, SIGNAL(rotateTheseSig(double, QList<int>)), this, SLOT(rotateThese( double, QList<int>)));
     dlg.exec();
@@ -1885,7 +1885,7 @@ void SurfaceManager::inspectWavefront(){
 
 #include <QMap>
 
-void plotlineThruAstigs(QwtPlot *plt, cv::Mat xastig, cv::Mat yastig, QList<rotationDef *>list){
+void plotlineThruAstigs(QwtPlot *plt, cv::Mat xastig, cv::Mat yastig, const QList<rotationDef *>&list){
 
   QList<rotationDef *> tmplist = list;
   QList<QPointF> values;
@@ -2770,7 +2770,7 @@ void SurfaceManager::showAllContours(){
     w->show();
     QApplication::restoreOverrideCursor();
 }
-void showImage(QImage img, QString title){
+void showImage(const QImage &img, const QString &title){
     QLabel *myLabel = new QLabel;
     myLabel->setPixmap(QPixmap::fromImage(img.scaled(1000,1000)));
     myLabel->setWindowTitle(title);

--- a/surfacemanager.h
+++ b/surfacemanager.h
@@ -70,14 +70,14 @@ public:
     void processSmoothing();
     void saveAllWaveFrontStats();
     void SaveWavefronts(bool saveNulled);
-    void writeWavefront(QString fname, wavefront *wf, bool saveNulled);
+    void writeWavefront(const QString &fname, wavefront *wf, bool saveNulled);
     void useDemoWaveFront();
     void showUnwrap();
     void initWaveFrontLoad();
-    void averageWavefrontFiles(QStringList files);
+    void averageWavefrontFiles(const QStringList &files);
     void downSizeWf(wavefront *wf);
     void process(int wavefront_index, SurfaceManager *sm);
-    wavefront *readWaveFront(QString fileName);
+    wavefront *readWaveFront(const QString &fileName);
     inline wavefront *getCurrent(){
         if (m_wavefronts.size() == 0)
             return 0;
@@ -160,7 +160,7 @@ private slots:
     void backGroundUpdate();
     void deleteWaveFronts(QList<int> list);
     void average(QList<int> list);
-    void transfrom(QList<int> list);
+    void transfrom(const QList<int> &list);
     void filter();
     void saveAllContours();
     void enableTools();
@@ -179,10 +179,10 @@ private slots:
 public slots:
     void rotateThese(double angle, QList<int> list);
     void createSurfaceFromPhaseMap(cv::Mat phase, CircleOutline outside,
-                                   CircleOutline center, QString name,
+                                   CircleOutline center, const QString &name,
                                    QVector<std::vector<cv::Point> > polyArea= QVector<std::vector<cv::Point> >());
     void invert(QList<int> list);
-    void wftNameChanged(int, QString);
+    void wftNameChanged(int, const QString&);
     void showAllContours();
     void computeStandAstig(define_input *wizPage, QList<rotationDef *>);
     void ObstructionChanged();

--- a/utilil.cpp
+++ b/utilil.cpp
@@ -5,7 +5,7 @@
 #define WIDTH 12
 #define DIV 1048576ull
 
-long showmem(QString /*title*/){
+long showmem(const QString & /*title*/){
 
     //qDebug () << title;
     MEMORYSTATUSEX statex;

--- a/utilil.cpp
+++ b/utilil.cpp
@@ -28,5 +28,5 @@ long showmem(QString /*title*/){
      return statex.ullAvailVirtual/DIV;
 }
 #else
-int showmem(QString){return 1000;}
+int showmem(const QString&){return 1000;}
 #endif

--- a/utils.h
+++ b/utils.h
@@ -1,5 +1,5 @@
 #ifndef UTILS_H
 #define UTILS_H
-int showmem(QString title = "");
+int showmem(const QString &title = "");
 extern double outputLambda;
 #endif // UTILS_H

--- a/videosetupdlg.cpp
+++ b/videosetupdlg.cpp
@@ -1,7 +1,7 @@
 #include "videosetupdlg.h"
 #include "ui_videosetupdlg.h"
 #include <QSettings>
-videoSetupDlg::videoSetupDlg(QImage img, QWidget *parent) :
+videoSetupDlg::videoSetupDlg(const QImage &img, QWidget *parent) :
     QDialog(parent),
     ui(new Ui::videoSetupDlg)
 {

--- a/videosetupdlg.h
+++ b/videosetupdlg.h
@@ -13,7 +13,7 @@ class videoSetupDlg : public QDialog
     Q_OBJECT
 
 public:
-    explicit videoSetupDlg(QImage img, QWidget *parent = 0);
+    explicit videoSetupDlg(const QImage &img, QWidget *parent = 0);
     ~videoSetupDlg();
     QImage m_img;
     int fps();

--- a/wavefrontfilterdlg.cpp
+++ b/wavefrontfilterdlg.cpp
@@ -24,7 +24,7 @@ wavefrontFilterDlg::~wavefrontFilterDlg()
 {
     delete ui;
 }
-void wavefrontFilterDlg::waveSelected(QString w){
+void wavefrontFilterDlg::waveSelected(const QString &w){
     emit waveWasSelected(w);
 }
 void wavefrontFilterDlg::setRemoveFileMode(){
@@ -46,10 +46,10 @@ void wavefrontFilterDlg::on_rmsValue_valueChanged(double arg1)
     QSettings set;
     set.setValue("filterRMS", arg1);
 }
-void wavefrontFilterDlg::addAstigValue(QString name, QPointF value){
+void wavefrontFilterDlg::addAstigValue(const QString &name, QPointF value){
     ui->astigPlot->addValue(name,value);
 }
-void wavefrontFilterDlg::addRMSValue(QString name, QPointF value){
+void wavefrontFilterDlg::addRMSValue(const QString &name, QPointF value){
     ui->rmSPlot->addValue(name, value);
 }
 void wavefrontFilterDlg::plot(){

--- a/wavefrontfilterdlg.h
+++ b/wavefrontfilterdlg.h
@@ -17,15 +17,15 @@ public:
     bool shouldFilterWavefront();
     bool shouldFilterFile();
     double rms();
-    void addRMSValue(QString name, QPointF value );
-    void addAstigValue(QString name, QPointF value);
+    void addRMSValue(const QString &name, QPointF value );
+    void addAstigValue(const QString &name, QPointF value);
     void plot();
     void setRemoveFileMode();
 signals:
     void waveWasSelected(QString m);
 private slots:
     void on_rmsValue_valueChanged(double arg1);
-    void waveSelected(QString m);
+    void waveSelected(const QString &m);
     void on_beepEnable_clicked(bool checked);
 
     void on_remove_clicked(bool checked);

--- a/wavefrontloader.cpp
+++ b/wavefrontloader.cpp
@@ -27,7 +27,7 @@ waveFrontLoader::waveFrontLoader(QObject *parent) :
     connect(this, SIGNAL(currentWavefront(QString)), pd, SLOT(setLabelText(QString)));
 }
 
-void waveFrontLoader::addWavefront(QString filename){
+void waveFrontLoader::addWavefront(const QString &filename){
     mutex.lock();
     m_list << filename;
     mutex.unlock();
@@ -38,7 +38,7 @@ void waveFrontLoader::cancel(){
     qDebug() << "trying to cancel";
 }
 
-void waveFrontLoader::loadx(QStringList list, SurfaceManager *sm){
+void waveFrontLoader::loadx(const QStringList &list, SurfaceManager *sm){
     m_list = list;
     loadx(sm);
 }

--- a/wavefrontloader.h
+++ b/wavefrontloader.h
@@ -29,7 +29,7 @@ class waveFrontLoader : public QObject
     Q_OBJECT
 public:
     explicit waveFrontLoader(QObject *parent = 0);
-    void addWavefront(QString filename);
+    void addWavefront(const QString &filename);
     bool done;
 signals:
     void status(int);
@@ -42,7 +42,7 @@ signals:
 
 public slots:
     void loadx(SurfaceManager *sm);
-    void loadx(QStringList list, SurfaceManager *sm);
+    void loadx(const QStringList &list, SurfaceManager *sm);
     void cancel();
 
 

--- a/wftstats.cpp
+++ b/wftstats.cpp
@@ -77,7 +77,7 @@ class ZernScaleDraw: public QwtScaleDraw
 {
 public:
     QVector<QString> m_names;
-    ZernScaleDraw(QVector<QString> names)
+    ZernScaleDraw(const QVector<QString> &names)
 
     {
         m_names = names;
@@ -182,7 +182,7 @@ void wftStats::computeZernStats( int ndx){
     }
 }
 
-QVector<int> histoz(const std::vector<double> data, int bins, double min, double max){
+QVector<int> histoz(const std::vector<double> &data, int bins, double min, double max){
     QVector<int> h(bins, 0);
     double interval = (max - min)/bins;
     for (unsigned int i = 0; i < data.size(); ++i){
@@ -233,7 +233,7 @@ void wftStats::computeWftStats( QVector<wavefront*> wavefronts, int ndx){
 
 }
 double histInterval ;
-QVector<int> histox(const std::vector<double> data, int bins){
+QVector<int> histox(const std::vector<double> &data, int bins){
     QVector<int> h(bins, 0);
 
     for (unsigned int i = 0; i < data.size(); ++i){

--- a/zernikedlg.cpp
+++ b/zernikedlg.cpp
@@ -38,7 +38,7 @@ ZernTableModel::ZernTableModel(QObject *parent, std::vector<bool> *enables, bool
 }
 
 
-void ZernTableModel::setValues(std::vector<double> vals, bool nulled){
+void ZernTableModel::setValues(const std::vector<double> &vals, bool nulled){
     m_nulled = nulled;
     values = vals;
     m_enables->resize(vals.size(),true);

--- a/zernikedlg.h
+++ b/zernikedlg.h
@@ -43,7 +43,7 @@ public:
     int columnCount(const QModelIndex &parent = QModelIndex()) const;
     void resizeRows(const int rowCnt);
     QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const;
-    void setValues(std::vector<double> vals, bool nulled);
+    void setValues(const std::vector<double> &vals, bool nulled);
     bool setData(const QModelIndex & index, const QVariant & value, int role = Qt::EditRole);
     Qt::ItemFlags flags(const QModelIndex & index) const ;
     QVariant headerData(int section, Qt::Orientation orientation, int role) const;

--- a/zernikeprocess.cpp
+++ b/zernikeprocess.cpp
@@ -1145,7 +1145,7 @@ arma::mat zernikeProcess::zpmC(arma::rowvec rho, arma::rowvec theta, int maxorde
     return zm;
 }
 
-arma::mat zernikeProcess::zapmC(const arma::rowvec& rho, const arma::rowvec& theta, const int& maxorder) {
+arma::mat zernikeProcess::zapmC(const arma::rowvec& rho, const arma::rowvec& theta, int maxorder) {
 
   unsigned int nrow = rho.size();
   int mmax = maxorder/2;

--- a/zernikeprocess.cpp
+++ b/zernikeprocess.cpp
@@ -1344,7 +1344,7 @@ std::vector<double>  zernikeProcess::ZernFitWavefront(wavefront &wf){
 }
 
 //debug routine to see what is matrix values.
-void dumpArma(arma::mat mm, QString title = "", QVector<QString> colHeading = QVector<QString>(0),
+void dumpArma(const arma::mat &mm, const QString &title = "", QVector<QString> colHeading = QVector<QString>(0),
               QVector<QString> RowLable = QVector<QString>(0)){
     arma::mat theMat = mm;
     QString transposed(" ");

--- a/zernikeprocess.h
+++ b/zernikeprocess.h
@@ -62,7 +62,7 @@ public:
     arma::mat rhotheta( int width, double radius, double cx, double cy, const wavefront *wf = 0);
 
     arma::mat zpmC(arma::rowvec rho, arma::rowvec theta, int maxorder);
-    arma::mat zapmC(const arma::rowvec& rho, const arma::rowvec& theta, const int& maxorder=12);
+    arma::mat zapmC(const arma::rowvec& rho, const arma::rowvec& theta, int maxorder =12);
     void fillVoid(wavefront &wf);
     void setMaxOrder(int n);
     int getNumberOfTerms();


### PR DESCRIPTION
I have used clazy to automatically use refs and values where it should.
`QPoint` is misleading but it's indeed a simple type to pass by value.
Notice there is no big risk changing type a to const type &a and reverse.

Those changes should bring a marginal efficiency gain. Nothing really measurable.