### PR TITLE
enable gc-section for lighter application

### DIFF
--- a/DFTFringe.pro
+++ b/DFTFringe.pro
@@ -20,6 +20,10 @@ qtHaveModule(printsupport): QT += printsupport
 
 QMAKE_CXXFLAGS += -std=c++17
 
+# Enable function/data sectioning and garbage collection by linker.
+QMAKE_CXXFLAGS += -ffunction-sections -fdata-sections
+QMAKE_LFLAGS += -Wl,--gc-sections
+
 # disable qDebug() in release
 CONFIG( release, debug|release ) {
     message("Release build")


### PR DESCRIPTION
These flags removes unused functions and variables from final binary. Makes it lighter.
It's safe, I have used those professionally for years.

Wa can still clean the code for readability #242