### PR TITLE
Fix test stand astig removal crash

### DIFF
--- a/contourplot.cpp
+++ b/contourplot.cpp
@@ -434,7 +434,8 @@ void ContourPlot::setSurface(wavefront * wf) {
         return;
 
     initPlot();
-    m_tools->enablTools(true);
+    if(m_tools != nullptr)
+        m_tools->enablTools(true);
     m_zOffset = 0.;
     ruler();
 


### PR DESCRIPTION
Fix #246 

This does fix the crash (https://github.com/githubdoe/DFTFringe/issues/250#issuecomment-3412063355).

However I do not like this fix because it doesn't explain why there was no crash in 7.4.0.
Maybe it's only masking something and it should be fixed at the root. I'm unsure if it's normal that `m_tools` can be null in this case.
