### PR TITLE
fix compass not working in 8.0.0

### DIFF
--- a/contourplot.cpp
+++ b/contourplot.cpp
@@ -491,8 +491,11 @@ ContourPlot::ContourPlot( QWidget *parent, ContourTools *tools, bool minimal ):
 
     tracker_ = new MyZoomer(this->canvas(), this);
 
-
-    connect(picker_, QOverload<const QPointF&>::of(&QwtPlotPicker::selected), this, &ContourPlot::selected);
+    // Using the old SIGNAL/SLOT syntax because problems with QWT.
+    // Qt is not able to match signal at runtime even if compile time checks all passed.
+    // ChatGPT tells it might be an ABI problem with QWT library but I (JST) have been unable to fix for now (2025-10-20).
+    connect(picker_, SIGNAL(selected(const QPointF&)), SLOT(selected(const QPointF&)));
+    //connect(picker_, QOverload<const QPointF&>::of(&QwtPlotPicker::selected), this, &ContourPlot::selected);
 
     QSettings settings;
     m_colorMapNdx = settings.value("colorMapType",0).toInt();

--- a/intensityplot.cpp
+++ b/intensityplot.cpp
@@ -145,7 +145,12 @@ intensityPlot::intensityPlot(QWidget *parent):
         new QwtCompassMagnetNeedle( QwtCompassMagnetNeedle::ThinStyle ) );
     compass->setValue( 0 );
     compass->setOrigin( -90 );
-    connect(compass,&QwtAbstractSlider::valueChanged,this ,&intensityPlot::angleChanged);
+
+    // Using the old SIGNAL/SLOT syntax because problems with QWT.
+    // Qt is not able to match signal at runtime even if compile time checks all passed.
+    // ChatGPT tells it might be an ABI problem with QWT library but I (JST) have been unable to fix for now (2025-10-20).
+    connect(compass, SIGNAL(valueChanged(double)), this ,SLOT(angleChanged(double)));
+    //connect(compass,&QwtAbstractSlider::valueChanged,this ,&intensityPlot::angleChanged);
 
     populate();
     resize(QGuiApplication::primaryScreen()->availableSize() * 1./ 5.);

--- a/profileplot.cpp
+++ b/profileplot.cpp
@@ -198,7 +198,13 @@ ProfilePlot::ProfilePlot(QWidget *parent , ContourTools *tools):
        // new QwtCompassMagnetNeedle( QwtCompassMagnetNeedle::ThinStyle ) );
     compass->setValue( 270 );
     compass->setOrigin( -90 );
-    connect(compass,&QwtAbstractSlider::valueChanged,this ,&ProfilePlot::angleChanged);
+    
+    // Using the old SIGNAL/SLOT syntax because problems with QWT.
+    // Qt is not able to match signal at runtime even if compile time checks all passed.
+    // ChatGPT tells it might be an ABI problem with QWT library but I (JST) have been unable to fix for now (2025-10-20).
+    connect(compass, SIGNAL(valueChanged(double)), this ,SLOT(angleChanged(double)));
+    //connect(compass,&QwtAbstractSlider::valueChanged,this ,&ProfilePlot::angleChanged);
+    
     connect(m_tools, &ContourTools::newDisplayErrorRange,
             this, &ProfilePlot::newDisplayErrorRange);
     connect(m_tools, &ContourTools::contourZeroOffsetChanged, this, &ProfilePlot::zeroOffsetChanged);


### PR DESCRIPTION
see #249. Compass was broken.

I was confident that the new style connect is wonderful and everything is checked at compile time. This is only partially true. 
While the signal/slot existence is checked at compile time you can still fail at runtime because of what could be ABI difference between library and main application. 

So for the moment, even if I'm not happy with this fix (not explaining/fixing the root cause) I propose to revert to old style to get the application to work.

When testing if you see any missed connect in logs, please inform me so that I revert them too.