### PR TITLE
[DRAFT FOR TESTS] adding clang tidy comments on modified code

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -12,6 +12,9 @@ env:
 
 jobs:
   build-linux:
+    permissions:
+      contents: read
+      pull-requests: write
     strategy:
       fail-fast: false
       matrix:
@@ -20,7 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: sudo apt update
-      - run: sudo apt install -y apt-utils build-essential wget qt6-base-dev-tools qt6-declarative-dev qt6-multimedia-dev libqt6charts6-dev libqt6datavisualization6-dev libqt6svg6-dev libopencv-core-dev libopencv-dev libqwt-qt5-6 libqwt-qt5-dev libarmadillo-dev libgl1-mesa-dev libglu1-mesa-dev
+      - run: sudo apt install -y apt-utils build-essential wget qt6-base-dev-tools qt6-declarative-dev qt6-multimedia-dev libqt6charts6-dev libqt6datavisualization6-dev libqt6svg6-dev libopencv-core-dev libopencv-dev libqwt-qt5-6 libqwt-qt5-dev libarmadillo-dev libgl1-mesa-dev libglu1-mesa-dev bear
       - run: wget -O qwt-${{env.QWT_version}}.zip https://sourceforge.net/projects/qwt/files/qwt/${{env.QWT_version}}/qwt-${{env.QWT_version}}.zip/download?use_mirror=pilotfiber
       - run: 7z x qwt-${{env.QWT_version}}.zip
       - run: cd qwt-${{env.QWT_version}} ; /usr/lib/qt6/bin/qmake
@@ -29,5 +32,20 @@ jobs:
       - run: /usr/lib/qt6/bin/qmake DFTFringe.pro
       - uses: ammaraskar/gcc-problem-matcher@master
       - run: echo "::add-matcher::.github/matcher/uic_matcher.json"
-      - run: make -j4
+
+      - name: capture compile_commands.json from build
+        run: bear -- make -j4
       - run: echo "::remove-matcher owner=uic-problem-matcher::"
+
+      - name: Run C++ Linter (clang-tidy)
+        if: strategy.job-index == 0 #run only for first OS of the matrix
+        uses: cpp-linter/cpp-linter-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          style: '' # we don't want check from clang-format
+          lines-changed-only: 'true' # Only lines in the diff that contain additions are analyzed. Avoid noise from existing code.
+          thread-comments: 'update'
+          tidy-review: true
+          passive-reviews: true
+          ignore: 'bezier|boost|SingleApplication|spdlog|zernike|moc_*|ui_*|qwt*'


### PR DESCRIPTION
This is a new github action for code quality. It should annotate code based on advanced checks (that we can fine tune) https://clang.llvm.org/extra/clang-tidy/checks/list.html

I made it so that only new code will be annotated and we live with older code as it is.

I'm working on this and not on some other more important features because I want to try it out and eventually reuse it at work.