### PR TITLE
Updates README.md and CI to explicitly pass DFTFringe.pro to qmake for linux builds

### DIFF
--- a/.github/workflows/build-linux-clazy.yml
+++ b/.github/workflows/build-linux-clazy.yml
@@ -31,7 +31,7 @@ jobs:
           /usr/lib/qt6/bin/qmake
           make -j4
           sudo make install
-      - run: /usr/lib/qt6/bin/qmake -spec linux-clang QMAKE_CXX="clazy"
+      - run: /usr/lib/qt6/bin/qmake DFTFringe.pro -spec linux-clang QMAKE_CXX="clazy"
       - uses: ammaraskar/gcc-problem-matcher@master
       # ignore noisy dirs from QT files itself
       # all level 1 checks but ignore clazy-no-connect-by-name

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -26,7 +26,7 @@ jobs:
       - run: cd qwt-${{env.QWT_version}} ; /usr/lib/qt6/bin/qmake
       - run: cd qwt-${{env.QWT_version}} ; make -j4
       - run: cd qwt-${{env.QWT_version}} ; sudo make install
-      - run: /usr/lib/qt6/bin/qmake
+      - run: /usr/lib/qt6/bin/qmake DFTFringe.pro
       - uses: ammaraskar/gcc-problem-matcher@master
       - run: echo "::add-matcher::.github/matcher/uic_matcher.json"
       - run: make -j4

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ cd qwt-6.3.0
 make -j4
 sudo make install
 cd ..
-/usr/lib/qt6/bin/qmake
+/usr/lib/qt6/bin/qmake DFTFringe.pro
 make -j4
 ```
 


### PR DESCRIPTION
I propose to also change the CI workflows as a matter of consistency ?