### PR TITLE
Bump Armadillo vesion to latest 14.4.0 to 15.2.2

### DIFF
--- a/.github/workflows/build-windows-QT5.yml
+++ b/.github/workflows/build-windows-QT5.yml
@@ -8,7 +8,7 @@ on:
   workflow_call:
 
 env:
-  armadillo_version: 14.4.0
+  armadillo_version: 15.2.2
   QWT_version: 6.1.6
   openCV_version: 4.6.0
   QT_version: 5.15.2
@@ -375,4 +375,3 @@ jobs:
           path: |
             DFTFringeInstaller_QT5_${{env.WORKFLOW_VERSION}}.exe
             DFTFringe.exe.debug
-

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -8,7 +8,7 @@ on:
   workflow_call:
 
 env:
-  armadillo_version: 14.4.0
+  armadillo_version: 15.2.2
   QWT_version: 6.3.0
   openCV_version: 4.12.0
   QT_version: 6.8.3

--- a/README.md
+++ b/README.md
@@ -179,11 +179,11 @@ cmake --build ./build_lapack -j4
 
 #### Build Armadillo
 
-Get [Armadillo](https://arma.sourceforge.net/) source code version 14.4.0 in your prefered way (clone the repo, download the archive, homing pigeon, ...) and have it in folder named `C:\buildingDFTFringe\armadillo-14.4.0`.
+Get [Armadillo](https://arma.sourceforge.net/) source code version 15.2.2 in your prefered way (clone the repo, download the archive, homing pigeon, ...) and have it in folder named `C:\buildingDFTFringe\armadillo-15.2.2`.
 
 Then from within `C:\buildingDFTFringe` do the following:  
 ```
-cmake -D CMAKE_PREFIX_PATH=C:/buildingDFTFringe/build_lapack -G "MinGW Makefiles" -S armadillo-14.4.0 -B build_armadillo
+cmake -D CMAKE_PREFIX_PATH=C:/buildingDFTFringe/build_lapack -G "MinGW Makefiles" -S armadillo-15.2.2 -B build_armadillo
 cmake --build ./build_armadillo -j4
 ```
 
@@ -205,10 +205,10 @@ No additional modification required here.
 
 #### Build Armadillo
 
-Get [Armadillo](https://arma.sourceforge.net/) source code version 14.4.0 in your prefered way (clone the repo, download the archive, homing pigeon, ...) and have it in folder named `C:\buildingDFTFringe\armadillo-14.4.0`.
+Get [Armadillo](https://arma.sourceforge.net/) source code version 15.2.2 in your prefered way (clone the repo, download the archive, homing pigeon, ...) and have it in folder named `C:\buildingDFTFringe\armadillo-15.2.2`.
 
 Then follow the information in `DFTFringe.pro` to create appropriate folders for header files and DLLs.  
-Copy content from `armadillo-14.4.0\include` to `build_armadillo\tmp\include`. 
+Copy content from `armadillo-15.2.2\include` to `build_armadillo\tmp\include`. 
 
 #### Copy all the DLLs
 


### PR DESCRIPTION
Previous version dated from February 2025. There have been several releases since then.

v15.x.x requires C++14 minimum. Dale still compiles C++11 but he also uses older Arma so this is fine.

https://sourceforge.net/p/arma/news/