### PR TITLE
Right side tabbed tools can be much smaller (250pix versus 524pix)

### DIFF
--- a/contourtools.ui
+++ b/contourtools.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>451</width>
+    <width>250</width>
     <height>497</height>
    </rect>
   </property>
@@ -18,7 +18,7 @@
   </property>
   <property name="minimumSize">
    <size>
-    <width>451</width>
+    <width>250</width>
     <height>411</height>
    </size>
   </property>

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1065</width>
+    <width>667</width>
     <height>905</height>
    </rect>
   </property>
@@ -18,7 +18,7 @@
   </property>
   <property name="minimumSize">
    <size>
-    <width>640</width>
+    <width>250</width>
     <height>640</height>
    </size>
   </property>
@@ -58,8 +58,8 @@
     <rect>
      <x>0</x>
      <y>0</y>
-     <width>1065</width>
-     <height>19</height>
+     <width>667</width>
+     <height>22</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuFiles">
@@ -161,7 +161,7 @@
    </property>
    <property name="minimumSize">
     <size>
-     <width>475</width>
+     <width>250</width>
      <height>791</height>
     </size>
    </property>
@@ -430,7 +430,7 @@ QPushButton:hover{rgb(85, 255, 255)}</string>
             </property>
             <property name="minimumSize">
              <size>
-              <width>74</width>
+              <width>82</width>
               <height>0</height>
              </size>
             </property>
@@ -502,7 +502,7 @@ QPushButton:hover{rgb(85, 255, 255)}</string>
             </property>
             <property name="minimumSize">
              <size>
-              <width>74</width>
+              <width>82</width>
               <height>30</height>
              </size>
             </property>
@@ -608,7 +608,7 @@ em;
           </property>
           <property name="minimumSize">
            <size>
-            <width>74</width>
+            <width>82</width>
             <height>0</height>
            </size>
           </property>
@@ -654,7 +654,7 @@ em;
           </property>
           <property name="minimumSize">
            <size>
-            <width>74</width>
+            <width>82</width>
             <height>0</height>
            </size>
           </property>
@@ -697,7 +697,7 @@ em;
           </property>
           <property name="minimumSize">
            <size>
-            <width>74</width>
+            <width>82</width>
             <height>0</height>
            </size>
           </property>
@@ -746,7 +746,7 @@ em;
           </property>
           <property name="minimumSize">
            <size>
-            <width>74</width>
+            <width>82</width>
             <height>0</height>
            </size>
           </property>
@@ -789,7 +789,7 @@ em;
           </property>
           <property name="minimumSize">
            <size>
-            <width>74</width>
+            <width>82</width>
             <height>0</height>
            </size>
           </property>
@@ -838,7 +838,7 @@ em;
           </property>
           <property name="minimumSize">
            <size>
-            <width>74</width>
+            <width>82</width>
             <height>0</height>
            </size>
           </property>
@@ -881,7 +881,7 @@ em;
           </property>
           <property name="minimumSize">
            <size>
-            <width>46</width>
+            <width>50</width>
             <height>0</height>
            </size>
           </property>
@@ -972,7 +972,7 @@ em;
          </property>
          <property name="minimumSize">
           <size>
-           <width>74</width>
+           <width>82</width>
            <height>0</height>
           </size>
          </property>

--- a/surfaceanalysistools.ui
+++ b/surfaceanalysistools.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>524</width>
+    <width>250</width>
     <height>733</height>
    </rect>
   </property>
@@ -18,7 +18,7 @@
   </property>
   <property name="minimumSize">
    <size>
-    <width>524</width>
+    <width>250</width>
     <height>497</height>
    </size>
   </property>


### PR DESCRIPTION
This will greatly help the app fit on smaller displays or displays where scaling is > 200%.

This was a new issue for Dale when we switched to QT6 but also has been an issue with people whose screen width is < 1280 pixels.

This will help everyone, even people with large displays as you can choose to allocate less space for the right side tool area and give more display area to other things.

I was able to achieve this by simply changing the minimum widths to 250 for all the .ui files that have to fit in that right pane.  The gui editor in QT was very helpful by showing what it would look like as I made the tools wider and thinner.




![temp_gif2](https://github.com/user-attachments/assets/00ad3094-c76e-4a11-b67c-6a404ec61dd9)

Fixes #289 