### PR TITLE
adding clang-tidy review for pull requests

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,6 @@
+Checks: >
+  clang-analyzer-*
+  bugprone-*
+  performance-unnecessary-*
+  modernize-use-nullptr
+  modernize-use-nodiscard

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -46,6 +46,7 @@ jobs:
           style: '' # we don't want check from clang-format
           lines-changed-only: 'true' # Only lines in the diff that contain additions are analyzed. Avoid noise from existing code.
           thread-comments: 'update'
+          tidy-checks: '' # rely solely on .clang-tidy file
           tidy-review: true
           passive-reviews: true
           ignore: 'bezier|boost|SingleApplication|spdlog|zernike|moc_*|ui_*|qwt*'


### PR DESCRIPTION
This is a new github action for code quality. It should annotate code based on advanced checks (that we can fine tune) https://clang.llvm.org/extra/clang-tidy/checks/list.html

I made it so that only new code will be annotated and we live with older code as it is.

This is an example of what it would look like if it was active on #263 
https://github.com/atsju/DFTFringe/pull/51/files#diff-06bf2ef5cae34afe079d755885471c5d1374ff88dd3384491e1f290d2c72eb73
@gr5 @githubdoe  let me know what you think.

Not all remarks are to be fixed but some of them are just excellent (https://github.com/atsju/DFTFringe/pull/51/files#r2595159192)
Some are really good practice (override, nullptr, naming 3 chars mini, magic numbers, ...)

However some fixes are only C++11 or C++17 compliant. So it would be easier if we do not have Qt5 to maintain (especially Dale version which I'm not even sure is C++11). Anyway, we can  still enable it, just remember to look for incompatibility before blindly accepting any proposed changes.