### PR TITLE
Made the 2 docking splitters have slightly wider, teal colored, much …

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -170,7 +170,7 @@ MainWindow::MainWindow(QWidget *parent) :
     m_profilePlot->setStyleSheet( {"border: 3px outset darkgrey;"});
     review->s1->addWidget(m_contourView);
     QRect rec = QGuiApplication::primaryScreen()->geometry();
-    review->s1->setSizes({INT_MAX, INT_MAX});
+    review->s1->setSizes({INT_MAX, INT_MAX}); // because these numbers are identical it will default split the 3d view and contour view 50/50
     review->s2->setSizes({ rec.height()/2,  rec.height()/2});
     review->s2->setStyleSheet(
         "QSplitter::handle:vertical{ border: 3px outset #004545; background: #ccffff }"
@@ -178,6 +178,10 @@ MainWindow::MainWindow(QWidget *parent) :
     review->s1->setStyleSheet(
           "QSplitter::handle:horizontal{ border: 3px outset #004545; background: #ccffff }"
     );
+
+    // make docking border separators larger and teal so they are more obvious to users
+    setStyleSheet(
+        "QMainWindow::separator { width: 4px; border: 3px outset #004545; background: #ccffff }");
 
     //Surface Manager
     m_surfaceManager = SurfaceManager::get_instance(this,m_surfTools, m_profilePlot, m_contourView,


### PR DESCRIPTION
I simply made these draggable partitions more visible to hopefully make it easier for users to realize that they can resize the left and right docks.

<img width="1826" height="992" alt="image" src="https://github.com/user-attachments/assets/9ef3dfb1-d646-4f4f-9986-2a193461efa3" />


I'll post how it looks at 200% scale once this PR creates the QT6 build (I have 2 windows computers and I'm at our second home on my laptop which doesn't have QT6 configured yet)