### PR TITLE
Fixes crash in "percent of correction" feature

### DIFF
--- a/RevisionHistory.html
+++ b/RevisionHistory.html
@@ -10,7 +10,7 @@
     <h1>DFTFringe Version History</h1>
     <ul>
 
-        <li>Version 8.3.0</li>
+        <li>Version 8.3.1</li>
         <ul>
             <li>Auto-invert feature (and dialog) only applies to wavefronts created form igram, not those loaded from file, simulated, averaged, subtracted, etc.</li>
             <li>Contourview display is always perfectly square</li>
@@ -19,12 +19,13 @@
             <li>Fixed crash in "show statistics"</li>
             <li>Disabled dark mode on windows</li>
             <li>Updated dependencies versions</li>
+            <li>Configuration Preferences look cleaner and some spellings fixed</li>
             <li>Changes to profile plot:</li>
             <ul>
                 <li>Some features moved to context menu (right click menu)</li>
                 <li>Selecting multiple wavefronts on right show their corresponding profiles</li>
-                <li>New average feature that uses all data (not just 16 diameters)<li>
-                <li>Ability to create wavefront based on average profile<li>
+                <li>New average feature that uses all data (not just 16 diameters)</li>
+                <li>Ability to create wavefront based on average profile</li>
                 <li>Corrected bugs with percentages, inches, mm</li>
                 <li>Select multiple wavefronts and right click to see multiple Ronchi view</li>
                 <li>Multi Ronchi view lets you compare Ronchi's</li>

--- a/percentcorrectiondlg.cpp
+++ b/percentcorrectiondlg.cpp
@@ -54,6 +54,8 @@ percentCorrectionDlg::percentCorrectionDlg( QWidget *parent) :
     sizes << 500 << 100;
     ui->splitter->setSizes(sizes);
     m_number_of_zones = set.value("percent number of zones", 5).toInt();
+    if (m_number_of_zones <= 0)
+        m_number_of_zones = 5;
     m_exclusionRadius = ui->exclusionRadius->value();
     ui->numberOfZones->blockSignals(true);
     ui->numberOfZones->setValue(m_number_of_zones);
@@ -105,11 +107,13 @@ QList<double> percentCorrectionDlg::generateZoneCenters(double radius, int numbe
             QJsonObject jsonData=doc.object();
 
             QJsonArray zones = jsonData["zones"].toArray();
-            m_number_of_zones = zones.size();
-            ui->numberOfZones->blockSignals(true);
-            ui->numberOfZones->setValue(m_number_of_zones);
-            ui->numberOfZones->blockSignals(false);
-            return m_zoneCenters;
+            if (zones.size() > 0) {
+                m_number_of_zones = zones.size();
+                ui->numberOfZones->blockSignals(true);
+                ui->numberOfZones->setValue(m_number_of_zones);
+                ui->numberOfZones->blockSignals(false);
+                return m_zoneCenters;
+            }
         }
 
     }


### PR DESCRIPTION
So this may be crazy because I might be the only person on the planet with these bad registry values.  I don't know how I created these registry values but it was just me messing around and testing the feature a while back (maybe a few months?).  It's possible that the only version of DFTF that can create these bad registry values was never released but just in case I want this fixed.

Anyway these were my values for 2 items in the registry and they caused a crash:

```
correctionZones              @ByteArray({"ROC":0,"mirror radius":73.025,"zones":[]})
percent number of zones      0
```
The code changes in this PR forces DFTF to go to default zones (5 zones with reasonable values) if zones is zero.