### PR TITLE
Allows compatibility with older wavefront (.wft) files

### DIFF
--- a/surfacemanager.cpp
+++ b/surfacemanager.cpp
@@ -1199,7 +1199,7 @@ wavefront * SurfaceManager::readWaveFront(const QString &fileName){
             md->m_outlineShape = ELLIPSE;
             iss >> dummy >> md->m_verticalAxis;
         }
-        if (l.startsWith("Do Not use null") || l.startsWith("nulled"){
+        if (l.startsWith("Do Not use null") || l.startsWith("nulled") ){
             wf->useSANull = false;
         }
     }


### PR DESCRIPTION
Sorin noticed this "bug" introduced in v7.3.1. This only affects people who create wft files with other software.  Software other than DFTFringe.