### PR TITLE
average profiles now get slope feature as well where slope is in orange.

### DIFF
--- a/profileplot.cpp
+++ b/profileplot.cpp
@@ -820,7 +820,17 @@ qDebug() << "Populate";
               left = transform.map(left);
               left.append(right);
 
-              QwtPlotCurve *cprofileavg = new QwtPlotCurve( name + " avg");
+              ProfileCurve *cprofileavg = new ProfileCurve( name + " avg");
+              if (left.size() >= 2) {
+                  // Distance between two samples
+                  double xDel = fabs(left[0].x() - left[1].x());
+
+                  // Recalculate hDelLimit using this specific xDel
+                  double hDelLimit = m_showNm * m_showSurface * ((outputLambda/m_wf->lambda) * fabs(xDel * tan(arcsecLimit)) / (outputLambda * 1.e-6));
+
+                  cprofileavg->setSlopeSettings(m_showSlopeError, hDelLimit, Settings2::m_profile->slopeErrorWidth());
+              }
+
               cprofileavg->setRenderHint( QwtPlotItem::RenderAntialiased );
               cprofileavg->setLegendAttribute( QwtPlotCurve::LegendShowSymbol, false );
               cprofileavg->setLegendIconSize(QSize(50,20));


### PR DESCRIPTION
I don't understand what I did but it seems to work.  I don't understand the calculations of xDel and hDelLimit and so on.  Well I get lambda - that's the wavelength.  But it seems to work perfectly so I think I did it right.

All the code is cut and pasted except as you can see I changed an object from class QwtPlotCurve to ProfileCurve (ProfileCurve has ability to show slope and QwtPlotCurve does not).

Anyway I tested it against the non average and it seems to show slope in the same steepness.