### PR TITLE
Stop reading CV_8U masks through bool, which clang miscompiles

### DIFF
--- a/dftarea.cpp
+++ b/dftarea.cpp
@@ -722,7 +722,11 @@ cv::Mat DFTArea::vortex(QImage &img, double low)
     imageMat.release();
 
     int count = 0;
-    bool *bp = m_mask.ptr<bool>(0);
+    // m_mask is CV_8UC1 holding 0 or 255. Reading those bytes through a bool
+    // pointer is undefined behaviour, and clang at -O2 evaluates every element
+    // as false, which leaves count at 0 and makes m2 below a NaN that then
+    // spreads through the whole wavefront.
+    const uchar *bp = m_mask.ptr<uchar>(0);
     for (int i = 0; i < size; ++i){
         if (bp[i]){
             sum += q[i];
@@ -940,7 +944,11 @@ cv::Mat DFTArea::vortex(QImage &img, double low)
     }
 
 }
-cv::Mat_<double> subtractPlane(cv::Mat_<double> phase, cv::Mat_<bool> mask){
+// The mask is CV_8UC1 holding 0 or 255. Taking it as Mat_<bool> and reading the
+// elements as bool is undefined behaviour: clang at -O2 sees every element as
+// false, so nothing is accumulated, cv::solve runs on an uninitialised X and Z,
+// and newPhase is returned without ever being written.
+cv::Mat_<double> subtractPlane(cv::Mat_<double> phase, cv::Mat_<uint8_t> mask){
     cv::Mat_<double> coeff(3,1);
     cv::Mat_<double> X(phase.rows * phase.cols,3);
     cv::Mat_<double> Z(phase.rows * phase.cols,1);
@@ -960,7 +968,9 @@ cv::Mat_<double> subtractPlane(cv::Mat_<double> phase, cv::Mat_<bool> mask){
     // distance calculation d = Ax + By - z + C / sqrt(A^2 + B^2 + C^2)
 
 
-    cv::Mat_<double> newPhase(phase.size());
+    // Only the masked pixels are written below, so the rest would otherwise be
+    // returned uninitialised.
+    cv::Mat_<double> newPhase = cv::Mat_<double>::zeros(phase.size());
     for (int y = 0; y < phase.rows; ++y){
         for (int x = 0; x  < phase.cols; ++x){
             int b = (int)mask(y,x);

--- a/dftarea.cpp
+++ b/dftarea.cpp
@@ -964,8 +964,6 @@ cv::Mat_<double> subtractPlane(cv::Mat_<double> phase, cv::Mat_<uint8_t> mask){
     // distance calculation d = Ax + By - z + C / sqrt(A^2 + B^2 + C^2)
 
 
-    // Only the masked pixels are written below, so the rest would otherwise be
-    // returned uninitialised.
     cv::Mat_<double> newPhase = cv::Mat_<double>::zeros(phase.size());
     for (int y = 0; y < phase.rows; ++y){
         for (int x = 0; x  < phase.cols; ++x){

--- a/dftarea.cpp
+++ b/dftarea.cpp
@@ -944,10 +944,6 @@ cv::Mat DFTArea::vortex(QImage &img, double low)
     }
 
 }
-// The mask is CV_8UC1 holding 0 or 255. Taking it as Mat_<bool> and reading the
-// elements as bool is undefined behaviour: clang at -O2 sees every element as
-// false, so nothing is accumulated, cv::solve runs on an uninitialised X and Z,
-// and newPhase is returned without ever being written.
 cv::Mat_<double> subtractPlane(cv::Mat_<double> phase, cv::Mat_<uint8_t> mask){
     cv::Mat_<double> coeff(3,1);
     cv::Mat_<double> X(phase.rows * phase.cols,3);

--- a/dftarea.cpp
+++ b/dftarea.cpp
@@ -722,10 +722,6 @@ cv::Mat DFTArea::vortex(QImage &img, double low)
     imageMat.release();
 
     int count = 0;
-    // m_mask is CV_8UC1 holding 0 or 255. Reading those bytes through a bool
-    // pointer is undefined behaviour, and clang at -O2 evaluates every element
-    // as false, which leaves count at 0 and makes m2 below a NaN that then
-    // spreads through the whole wavefront.
     const uchar *bp = m_mask.ptr<uchar>(0);
     for (int i = 0; i < size; ++i){
         if (bp[i]){

--- a/profileplot.cpp
+++ b/profileplot.cpp
@@ -464,7 +464,10 @@ QPolygonF ProfilePlot::createProfile(double units, const wavefront *wf, bool all
         }
 
         // Mask and Data Processing
-        if (wf->workMask.at<bool>(dy, dx)) {
+        // workMask is Mat_<uint8_t> holding 0 or 255. Reading it as bool is
+        // undefined behaviour and clang at -O2 sees every element as false,
+        // which leaves the profile with no points at all.
+        if (wf->workMask.at<uint8_t>(dy, dx)) {
             double val = (units * (wf->workData(dy, dx)) * wf->lambda / outputLambda) + (offset * units);
 
             if (m_defocus_mode) {

--- a/profileplot.cpp
+++ b/profileplot.cpp
@@ -464,9 +464,6 @@ QPolygonF ProfilePlot::createProfile(double units, const wavefront *wf, bool all
         }
 
         // Mask and Data Processing
-        // workMask is Mat_<uint8_t> holding 0 or 255. Reading it as bool is
-        // undefined behaviour and clang at -O2 sees every element as false,
-        // which leaves the profile with no points at all.
         if (wf->workMask.at<uint8_t>(dy, dx)) {
             double val = (units * (wf->workData(dy, dx)) * wf->lambda / outputLambda) + (offset * units);
 

--- a/surfacemanager.h
+++ b/surfacemanager.h
@@ -106,7 +106,7 @@ public:
     int messageResult;
     void inspectWavefront();
 
-    cv::Mat_<double> subtractPlane(cv::Mat_<double> phase, cv::Mat_<bool> mask);
+    cv::Mat_<double> subtractPlane(cv::Mat_<double> phase, cv::Mat_<uint8_t> mask);
 
     void average(QList<wavefront *> wfList);
     void subtractWavefronts();


### PR DESCRIPTION
Note : this problem was diagnosed and fixed by Opus 5, but it allowed me to obtain wavefront generation on Mac OS with the latest codebase state.

There is a change in behaviour, newPhase is now initialized with zeros, and wasn't before.

It's currently building for all platforms : https://github.com/Lucassifoni/DFTFringe/actions?query=branch%3Afix-bool-mask-aliasing 

---- BEGIN AI-generated summary ----

makeMask returns CV_8UC1 holding 0 or 255, and wavefront::workMask is Mat_<uint8_t>. Three places read those bytes as bool. That is undefined behaviour, and while gcc happens to treat any non zero byte as true, clang at -O2 evaluates every element as false. A release build made with clang is therefore silently wrong:

- dftarea.cpp, in vortex(): count stays 0, so m2 becomes 0.0/0 and the subtraction that follows fills the whole image with NaN. Every wavefront computed from an interferogram ends up NaN, and so does every Zernike term.
- dftarea.cpp, in subtractPlane(): nothing is accumulated, cv::solve runs on an uninitialised X and Z, and newPhase is returned without being written.
- profileplot.cpp: no point passes the mask test, so the profile plot is empty.

Read the masks as uint8_t instead, and zero newPhase, whose unmasked pixels were never written.

Reproduced with clang 17 on arm64: reading a 255 byte through bool* yields false at -O2 and true at -O0.