### PR TITLE
fix outline helper not closing on app close

### DIFF
--- a/jitteroutlinedlg.cpp
+++ b/jitteroutlinedlg.cpp
@@ -1,23 +1,13 @@
 #include "jitteroutlinedlg.h"
 #include "ui_jitteroutlinedlg.h"
-#include "mainwindow.h"
-jitterOutlineDlg *jitterOutlineDlg::m_instance = 0;
 
 jitterOutlineDlg::jitterOutlineDlg(QWidget *parent) :
     QDialog(parent),
     ui(new Ui::jitterOutlineDlg)
 {
     ui->setupUi(this);
-}
-
-jitterOutlineDlg *jitterOutlineDlg::getInstance(MainWindow *mw){
-    if (m_instance ==0){
-        m_instance=  new jitterOutlineDlg;
-        connect(m_instance->ui->startPb, &QAbstractButton::clicked, mw,&MainWindow::startJitter);
-        connect(m_instance->ui->StopPb, &QAbstractButton::clicked,mw,&MainWindow::stopJitter);
-    }
-    return m_instance;
-
+    connect(ui->startPb, &QAbstractButton::clicked, this, &jitterOutlineDlg::startRequested);
+    connect(ui->StopPb, &QAbstractButton::clicked, this, &jitterOutlineDlg::stopRequested);
 }
 
 jitterOutlineDlg::~jitterOutlineDlg()

--- a/jitteroutlinedlg.h
+++ b/jitteroutlinedlg.h
@@ -3,7 +3,6 @@
 
 #include <QDialog>
 #include <QProgressBar>
-class MainWindow;
 namespace Ui {
 class jitterOutlineDlg;
 }
@@ -13,9 +12,7 @@ class jitterOutlineDlg : public QDialog
     Q_OBJECT
 
 public:
-    static jitterOutlineDlg *m_instance;
     explicit jitterOutlineDlg(QWidget *parent = 0);
-    static jitterOutlineDlg *getInstance(MainWindow * mw);
     QProgressBar *getProgressBar();
 
     ~jitterOutlineDlg();
@@ -24,6 +21,10 @@ public:
     int getEnd();
     int getType();
     void status(const QString &status);
+
+signals:
+    void startRequested();
+    void stopRequested();
 
 private slots:
 

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -67,7 +67,7 @@ MainWindow *MainWindow::me = 0;
 MainWindow::MainWindow(QWidget *parent) :
     QMainWindow(parent),
     ui(new Ui::MainWindow),m_showChannels(false), m_showIntensity(false),m_inBatch(false),m_OutlineDoneInBatch(false),
-    m_batchMakeSurfaceReady(false), m_astigStatsDlg(0), m_jitterOutlineDlg(nullptr), m_cameraCalibWizard(nullptr)
+    m_batchMakeSurfaceReady(false), m_jitterOutlineDlg(nullptr), m_astigStatsDlg(0), m_cameraCalibWizard(nullptr)
 {
     ui->setupUi(this);
     ui->useAnnulust->hide();
@@ -1417,12 +1417,12 @@ void MainWindow::startJitter(){
         qApp->processEvents();
         wavefront *wf = m_surfaceManager->m_wavefronts[m_surfaceManager->m_currentNdx];
         wf->name = QString("x:_%1_Y:_%2_radius:_%3").arg(x).arg(y).arg(rad);
-        dlg->status(wf->name);
+        m_jitterOutlineDlg->status(wf->name);
         m_surfTools->nameChangedN(m_surfaceManager->m_currentNdx, wf->name);
         qApp->processEvents();
         QObject().thread()->msleep(500);
     }
-    dlg->getProgressBar()->reset();
+    m_jitterOutlineDlg->getProgressBar()->reset();
     stopJittering = false;
 
     m_igramArea->openImage(m_igramArea->m_filename);

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -66,8 +66,8 @@ MainWindow *MainWindow::me = 0;
 
 MainWindow::MainWindow(QWidget *parent) :
     QMainWindow(parent),
-    ui(new Ui::MainWindow),m_showChannels(false), m_showIntensity(false),m_inBatch(false),m_OutlineDoneInBatch(false),
-    m_batchMakeSurfaceReady(false), m_jitterOutlineDlg(nullptr), m_astigStatsDlg(0), m_cameraCalibWizard(nullptr)
+    ui(new Ui::MainWindow), m_jitterOutlineDlg(nullptr), m_showChannels(false), m_showIntensity(false), m_inBatch(false),
+    m_skipItem(false), m_OutlineDoneInBatch(false), m_batchMakeSurfaceReady(false), m_astigStatsDlg(0), m_cameraCalibWizard(nullptr)
 {
     ui->setupUi(this);
     ui->useAnnulust->hide();

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -47,6 +47,7 @@
 #include "regionedittools.h"
 #include "utils.h"
 #include "colorchannel.h"
+#include "jitteroutlinedlg.h"
 #include "opencv2/opencv.hpp"
 #include <QUrl>
 
@@ -66,7 +67,7 @@ MainWindow *MainWindow::me = 0;
 MainWindow::MainWindow(QWidget *parent) :
     QMainWindow(parent),
     ui(new Ui::MainWindow),m_showChannels(false), m_showIntensity(false),m_inBatch(false),m_OutlineDoneInBatch(false),
-    m_batchMakeSurfaceReady(false), m_astigStatsDlg(0), m_cameraCalibWizard(nullptr)
+    m_batchMakeSurfaceReady(false), m_astigStatsDlg(0), m_jitterOutlineDlg(nullptr), m_cameraCalibWizard(nullptr)
 {
     ui->setupUi(this);
     ui->useAnnulust->hide();
@@ -138,6 +139,10 @@ MainWindow::MainWindow(QWidget *parent) :
 
     m_contourTools = new ContourTools(this);
     m_outlineHelp = new outlineHelpDocWidget(this);
+    m_jitterOutlineDlg = new jitterOutlineDlg(this);
+    connect(m_jitterOutlineDlg, &jitterOutlineDlg::startRequested, this, &MainWindow::startJitter);
+    connect(m_jitterOutlineDlg, &jitterOutlineDlg::stopRequested, this, &MainWindow::stopJitter);
+    connect(m_jitterOutlineDlg, &QDialog::finished, this, &MainWindow::stopJitter);
     m_outlinePlots = new outlinePlots(this);
     m_surfTools = surfaceAnalysisTools::get_Instance(this);
     m_regionsEdit = new regionEditTools(this);
@@ -1349,13 +1354,9 @@ void MainWindow::on_actionVersion_History_triggered()
     QDesktopServices::openUrl(QUrl::fromLocalFile(link));
 }
 
-
-#include "jitteroutlinedlg.h"
 void MainWindow::on_actionIterate_outline_triggered()
 {
-    jitterOutlineDlg *dlg = jitterOutlineDlg::getInstance(this);
-    connect(dlg,&QDialog::finished,this,&MainWindow::stopJitter);
-    dlg->show();
+    m_jitterOutlineDlg->show();
 }
 static bool stopJittering = false;
 void MainWindow::stopJitter(){
@@ -1367,22 +1368,21 @@ void MainWindow::startJitter(){
         QMessageBox::warning(this, "Error", "You must first load an interferogram and outline the mirror. and press 'Done'");
         return;
     }
-    jitterOutlineDlg *dlg = jitterOutlineDlg::getInstance(this);
     stopJittering = false;
-    int start = dlg->getStart();
-    int end = dlg->getEnd();
-    int step = dlg->getStep();
+    int start = m_jitterOutlineDlg->getStart();
+    int end = m_jitterOutlineDlg->getEnd();
+    int step = m_jitterOutlineDlg->getStep();
     int x = 0;
     int y = 0;
     int rad = 0;
 
     m_igramArea->openImage(m_igramArea->m_filename);
     CircleOutline  saved = (m_igramArea->m_current_boundry == OutSideOutline) ? m_igramArea->m_outside : m_igramArea->m_center;
-    dlg->getProgressBar()->setMinimum(start);
-    dlg->getProgressBar()->setMaximum(end);
+    m_jitterOutlineDlg->getProgressBar()->setMinimum(start);
+    m_jitterOutlineDlg->getProgressBar()->setMaximum(end);
     for (int delta = start; delta <= end; delta += step){
-        dlg->getProgressBar()->setValue(delta);
-        switch (dlg->getType()){
+        m_jitterOutlineDlg->getProgressBar()->setValue(delta);
+        switch (m_jitterOutlineDlg->getType()){
         case 1:
             x = delta;
             break;

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -49,6 +49,7 @@
 #include "cameracalibwizard.h"
 
 class regionEditTools;
+class jitterOutlineDlg;
 namespace Ui {
 class MainWindow;
 }
@@ -301,6 +302,7 @@ private:
     ContourTools *m_contourTools;
     surfaceAnalysisTools *m_surfTools;
     outlineHelpDocWidget *m_outlineHelp;
+    jitterOutlineDlg *m_jitterOutlineDlg;
     regionEditTools *m_regionsEdit;
     SurfaceManager *m_surfaceManager;
     QScrollArea *scrollArea;


### PR DESCRIPTION
Fix one of the windows not closing identified in #82 

--------
This PR modernizes Outline Helper lifecycle management by replacing its static singleton access with a MainWindow-owned dialog instance.

The intent is to make window behavior more predictable: the dialog now follows Qt parent-child ownership, so it closes naturally with the main window.
It also improves separation of concerns by having the dialog emit user-intent signals (Start/Stop), while MainWindow handles the actual processing logic. This keeps UI code focused on interaction and makes behavior easier to reason about, test, and maintain over time.