### PR TITLE
Reviewed wavefront code 

### DIFF
--- a/surfacemanager.cpp
+++ b/surfacemanager.cpp
@@ -1821,7 +1821,7 @@ void SurfaceManager::average(QList<wavefront *> wfList){
 
 
     wavefront *wf = new wavefront();
-    *wf = *wfList[sizes[maxkey][0]];// copy in all the parameters (e.g. m_inside, lambda, diameter) from first wavefront to average
+    *wf = wfList[sizes[maxkey][0]]->copyShallow();
     wf->data = sum.clone();
     wf->mask = mask;
     wf->workMask = mask.clone();
@@ -1918,8 +1918,7 @@ void SurfaceManager::rotateThese(double angle, QList<int> list){
         wavefront *oldWf = m_wavefronts[list[i]];
         QStringList l = oldWf->name.split('.');
         QString newName = QString("%1_%2%3.wft").arg(l[0]).arg((angle >= 0) ? "CW":"CCW").arg(fabs(angle), 5, 'f', 1, QLatin1Char('0')); // clazy:exclude=qstring-arg
-        wavefront *wf = new wavefront();
-        *wf = *oldWf; // copy everything to new wavefront including basic things like diameter,wavelength,origin
+        wavefront *wf = new wavefront(oldWf->copyShallow());
         //emit nameChanged(wf->name, newName);
 
         wf->name = newName;
@@ -1990,8 +1989,7 @@ void SurfaceManager::subtract(wavefront *wf1, wavefront *wf2, bool use_null){
     cv::Mat result = wf1->data - resize;
 
     //result.copyTo(masked, mask);
-    wavefront *resultwf = new wavefront;
-    *resultwf = *wf1;
+    wavefront *resultwf = new wavefront(wf1->copyShallow());
     resultwf->data = result.clone();
     resultwf->mask = mask.clone();
     resultwf->workMask = mask.clone();
@@ -2415,7 +2413,7 @@ textres SurfaceManager::Phase2(QList<rotationDef *> list, QList<wavefront *> inp
         ContourPlot *cp = new ContourPlot();
         cp->m_zRangeMode = "Fractions of Wave";
         cp->contourWaveRangeChanged(inputs[0]->std* 3);
-        wavefront * wf = new wavefront(*inputs[i]); //TODO 1/2 sole usage of copy constructor 
+        wavefront * wf = new wavefront(inputs[i]->copyDeep());
 
 
         wf->data = wf->workData = standwfs[i];
@@ -2460,7 +2458,7 @@ textres SurfaceManager::Phase2(QList<rotationDef *> list, QList<wavefront *> inp
 
 
     //display average of all stand zernwavefronts
-    wavefront * wf2 = new wavefront(*inputs[0]); //TODO 2/2 sole usage of copy constructor
+    wavefront * wf2 = new wavefront(inputs[0]->copyDeep());
     wf2->data = wf2->workData = standavgZernMat ;
     cv::resize(inputs[0]->mask,wf2->mask, cv::Size(wf2->data.cols, wf2->data.rows));
     wf2->workMask = wf2->mask;
@@ -3333,8 +3331,7 @@ void SurfaceManager::memoryLow(){
         okToContinue = resp;
 }
 void SurfaceManager::resize( wavefront *wf, int size){
-    wavefront *nwf = new wavefront();
-    *nwf = *wf;
+    wavefront *nwf = new wavefront(wf->copyShallow());
     nwf->dirtyZerns = true;
     cv::Mat newData;
     cv::Mat newMask;
@@ -3357,8 +3354,7 @@ void SurfaceManager::resize( wavefront *wf, int size){
 
 }
 void SurfaceManager::changeWavelength( wavefront *wf, double wavelength){
-    wavefront *nwf = new wavefront();
-    *nwf = *wf;
+    wavefront *nwf = new wavefront(wf->copyShallow());
     nwf->dirtyZerns = true;
     nwf->data = nwf->data * ( wf->lambda/wavelength);
     nwf->lambda = wavelength;
@@ -3376,8 +3372,7 @@ void SurfaceManager::flipHorizontal( wavefront *wf){
     cv::flip(wf->data, newData, 1);
     cv::flip(wf->mask, newMask, 1);
 
-    wavefront *nwf = new wavefront();
-    *nwf = *wf;
+    wavefront *nwf = new wavefront(wf->copyShallow());
     nwf->dirtyZerns = true;
     nwf->m_inside.m_center.rx() = wf->data.cols-1 - wf->m_inside.m_center.x();
     nwf->m_outside.m_center.rx() = wf->data.cols-1 - wf->m_outside.m_center.x();
@@ -3401,8 +3396,7 @@ void SurfaceManager::flipVertical( wavefront *wf){
     cv::flip(wf->data, newData, 0);
     cv::flip(wf->mask, newMask, 0);
 
-    wavefront *nwf = new wavefront();
-    *nwf = *wf;
+    wavefront *nwf = new wavefront(wf->copyShallow());
     nwf->dirtyZerns = true;
     nwf->m_inside.m_center.rx() = wf->data.cols-1 - wf->m_inside.m_center.x();
     nwf->m_outside.m_center.rx() = wf->data.cols-1 - wf->m_outside.m_center.x();

--- a/surfacemanager.cpp
+++ b/surfacemanager.cpp
@@ -1821,7 +1821,7 @@ void SurfaceManager::average(QList<wavefront *> wfList){
 
 
     wavefront *wf = new wavefront();
-    *wf = wfList[sizes[maxkey][0]]->copyShallow();
+    *wf = *wfList[sizes[maxkey][0]];// copy in all the parameters (e.g. m_inside, lambda, diameter) from first wavefront to average
     wf->data = sum.clone();
     wf->mask = mask;
     wf->workMask = mask.clone();
@@ -1918,7 +1918,8 @@ void SurfaceManager::rotateThese(double angle, QList<int> list){
         wavefront *oldWf = m_wavefronts[list[i]];
         QStringList l = oldWf->name.split('.');
         QString newName = QString("%1_%2%3.wft").arg(l[0]).arg((angle >= 0) ? "CW":"CCW").arg(fabs(angle), 5, 'f', 1, QLatin1Char('0')); // clazy:exclude=qstring-arg
-        wavefront *wf = new wavefront(oldWf->copyShallow());
+        wavefront *wf = new wavefront();
+        *wf = *oldWf; // copy everything to new wavefront including basic things like diameter,wavelength,origin
         //emit nameChanged(wf->name, newName);
 
         wf->name = newName;
@@ -1989,7 +1990,8 @@ void SurfaceManager::subtract(wavefront *wf1, wavefront *wf2, bool use_null){
     cv::Mat result = wf1->data - resize;
 
     //result.copyTo(masked, mask);
-    wavefront *resultwf = new wavefront(wf1->copyShallow());
+    wavefront *resultwf = new wavefront;
+    *resultwf = *wf1;
     resultwf->data = result.clone();
     resultwf->mask = mask.clone();
     resultwf->workMask = mask.clone();
@@ -2413,7 +2415,8 @@ textres SurfaceManager::Phase2(QList<rotationDef *> list, QList<wavefront *> inp
         ContourPlot *cp = new ContourPlot();
         cp->m_zRangeMode = "Fractions of Wave";
         cp->contourWaveRangeChanged(inputs[0]->std* 3);
-        wavefront * wf = new wavefront(inputs[i]->copyDeep());
+        wavefront * wf = new wavefront(*inputs[i]);
+        wf->cloneMatricesFrom(*inputs[i]);
 
 
         wf->data = wf->workData = standwfs[i];
@@ -2458,7 +2461,8 @@ textres SurfaceManager::Phase2(QList<rotationDef *> list, QList<wavefront *> inp
 
 
     //display average of all stand zernwavefronts
-    wavefront * wf2 = new wavefront(inputs[0]->copyDeep());
+    wavefront * wf2 = new wavefront(*inputs[0]);
+    wf2->cloneMatricesFrom(*inputs[0]);
     wf2->data = wf2->workData = standavgZernMat ;
     cv::resize(inputs[0]->mask,wf2->mask, cv::Size(wf2->data.cols, wf2->data.rows));
     wf2->workMask = wf2->mask;
@@ -3331,7 +3335,8 @@ void SurfaceManager::memoryLow(){
         okToContinue = resp;
 }
 void SurfaceManager::resize( wavefront *wf, int size){
-    wavefront *nwf = new wavefront(wf->copyShallow());
+    wavefront *nwf = new wavefront();
+    *nwf = *wf;
     nwf->dirtyZerns = true;
     cv::Mat newData;
     cv::Mat newMask;
@@ -3354,7 +3359,8 @@ void SurfaceManager::resize( wavefront *wf, int size){
 
 }
 void SurfaceManager::changeWavelength( wavefront *wf, double wavelength){
-    wavefront *nwf = new wavefront(wf->copyShallow());
+    wavefront *nwf = new wavefront();
+    *nwf = *wf;
     nwf->dirtyZerns = true;
     nwf->data = nwf->data * ( wf->lambda/wavelength);
     nwf->lambda = wavelength;
@@ -3372,7 +3378,8 @@ void SurfaceManager::flipHorizontal( wavefront *wf){
     cv::flip(wf->data, newData, 1);
     cv::flip(wf->mask, newMask, 1);
 
-    wavefront *nwf = new wavefront(wf->copyShallow());
+    wavefront *nwf = new wavefront();
+    *nwf = *wf;
     nwf->dirtyZerns = true;
     nwf->m_inside.m_center.rx() = wf->data.cols-1 - wf->m_inside.m_center.x();
     nwf->m_outside.m_center.rx() = wf->data.cols-1 - wf->m_outside.m_center.x();
@@ -3396,7 +3403,8 @@ void SurfaceManager::flipVertical( wavefront *wf){
     cv::flip(wf->data, newData, 0);
     cv::flip(wf->mask, newMask, 0);
 
-    wavefront *nwf = new wavefront(wf->copyShallow());
+    wavefront *nwf = new wavefront();
+    *nwf = *wf;
     nwf->dirtyZerns = true;
     nwf->m_inside.m_center.rx() = wf->data.cols-1 - wf->m_inside.m_center.x();
     nwf->m_outside.m_center.rx() = wf->data.cols-1 - wf->m_outside.m_center.x();

--- a/surfacemanager.cpp
+++ b/surfacemanager.cpp
@@ -2415,7 +2415,7 @@ textres SurfaceManager::Phase2(QList<rotationDef *> list, QList<wavefront *> inp
         ContourPlot *cp = new ContourPlot();
         cp->m_zRangeMode = "Fractions of Wave";
         cp->contourWaveRangeChanged(inputs[0]->std* 3);
-        wavefront * wf = new wavefront(*inputs[i]);
+        wavefront * wf = new wavefront(*inputs[i]); //TODO 1/2 sole usage of copy constructor 
 
 
         wf->data = wf->workData = standwfs[i];
@@ -2460,7 +2460,7 @@ textres SurfaceManager::Phase2(QList<rotationDef *> list, QList<wavefront *> inp
 
 
     //display average of all stand zernwavefronts
-    wavefront * wf2 = new wavefront(*inputs[0]);
+    wavefront * wf2 = new wavefront(*inputs[0]); //TODO 2/2 sole usage of copy constructor
     wf2->data = wf2->workData = standavgZernMat ;
     cv::resize(inputs[0]->mask,wf2->mask, cv::Size(wf2->data.cols, wf2->data.rows));
     wf2->workMask = wf2->mask;

--- a/wavefront.cpp
+++ b/wavefront.cpp
@@ -22,34 +22,75 @@ wavefront::wavefront():
 {
 }
 
-wavefront::wavefront( const wavefront &wf): 
-    data(wf.data.clone()),
-    nulledData(wf.nulledData.clone()),
-    mask(wf.mask.clone()),
-    workData(wf.workData.clone()),
-    workMask(wf.workMask.clone()),
-    InputZerns(wf.InputZerns),
-    zernEnablesApplied(wf.zernEnablesApplied),
-    gaussian_diameter(wf.gaussian_diameter),
-    gbEnabled(wf.gbEnabled),
-    gbValue(wf.gbValue),
-    wasSmoothed(wf.wasSmoothed),
-    useSANull(wf.useSANull),
-    GBSmoothingValue(wf.GBSmoothingValue),
-    m_origin(wf.m_origin),
-    m_manuallyInverted(wf.m_manuallyInverted),
-    name(wf.name),
-    lambda(wf.lambda),
-    m_outside(wf.m_outside),
-    m_inside(wf.m_inside),
-    diameter(wf.diameter),
-    roc(wf.roc),
-    min(wf.min),
-    max(wf.max),
-    std(wf.std),
-    mean(wf.mean),
-    dirtyZerns(wf.dirtyZerns),
-    regions(wf.regions),
-    regions_have_been_expanded(wf.regions_have_been_expanded)
-{}
+wavefront wavefront::copyShallow() const
+{
+    wavefront out;
+    
+    // those are cv::mat objects. `=` operator will not copy the data, but will create a new header pointing to the same data. So it is a shallow copy.
+    out.data = data;
+    out.nulledData = nulledData;
+    out.mask = mask;
+    out.workData = workData;
+    out.workMask = workMask;
+
+    out.InputZerns = InputZerns;
+    out.zernEnablesApplied = zernEnablesApplied;
+    out.gaussian_diameter = gaussian_diameter;
+    out.gbEnabled = gbEnabled;
+    out.gbValue = gbValue;
+    out.wasSmoothed = wasSmoothed;
+    out.useSANull = useSANull;
+    out.GBSmoothingValue = GBSmoothingValue;
+    out.m_origin = m_origin;
+    out.m_manuallyInverted = m_manuallyInverted;
+    out.name = name;
+    out.lambda = lambda;
+    out.m_outside = m_outside;
+    out.m_inside = m_inside;
+    out.diameter = diameter;
+    out.roc = roc;
+    out.min = min;
+    out.max = max;
+    out.std = std;
+    out.mean = mean;
+    out.dirtyZerns = dirtyZerns;
+    out.regions = regions;
+    out.regions_have_been_expanded = regions_have_been_expanded;
+    return out;
+}
+
+wavefront wavefront::copyDeep() const
+{
+    wavefront out;
+    out.data = data.clone();
+    out.nulledData = nulledData.clone();
+    out.mask = mask.clone();
+    out.workData = workData.clone();
+    out.workMask = workMask.clone();
+    out.InputZerns = InputZerns;
+    out.zernEnablesApplied = zernEnablesApplied;
+    out.gaussian_diameter = gaussian_diameter;
+    out.gbEnabled = gbEnabled;
+    out.gbValue = gbValue;
+    out.wasSmoothed = wasSmoothed;
+    out.useSANull = useSANull;
+    out.GBSmoothingValue = GBSmoothingValue;
+    out.m_origin = m_origin;
+    out.m_manuallyInverted = m_manuallyInverted;
+    out.name = name;
+    out.lambda = lambda;
+    out.m_outside = m_outside;
+    out.m_inside = m_inside;
+    out.diameter = diameter;
+    out.roc = roc;
+    out.min = min;
+    out.max = max;
+    out.std = std;
+    out.mean = mean;
+    out.dirtyZerns = dirtyZerns;
+    out.regions = regions;
+    out.regions_have_been_expanded = regions_have_been_expanded;
+    return out;
+}
+
 

--- a/wavefront.cpp
+++ b/wavefront.cpp
@@ -22,75 +22,11 @@ wavefront::wavefront():
 {
 }
 
-wavefront wavefront::copyShallow() const
+void wavefront::cloneMatricesFrom(const wavefront &wf)
 {
-    wavefront out;
-    
-    // those are cv::mat objects. `=` operator will not copy the data, but will create a new header pointing to the same data. So it is a shallow copy.
-    out.data = data;
-    out.nulledData = nulledData;
-    out.mask = mask;
-    out.workData = workData;
-    out.workMask = workMask;
-
-    out.InputZerns = InputZerns;
-    out.zernEnablesApplied = zernEnablesApplied;
-    out.gaussian_diameter = gaussian_diameter;
-    out.gbEnabled = gbEnabled;
-    out.gbValue = gbValue;
-    out.wasSmoothed = wasSmoothed;
-    out.useSANull = useSANull;
-    out.GBSmoothingValue = GBSmoothingValue;
-    out.m_origin = m_origin;
-    out.m_manuallyInverted = m_manuallyInverted;
-    out.name = name;
-    out.lambda = lambda;
-    out.m_outside = m_outside;
-    out.m_inside = m_inside;
-    out.diameter = diameter;
-    out.roc = roc;
-    out.min = min;
-    out.max = max;
-    out.std = std;
-    out.mean = mean;
-    out.dirtyZerns = dirtyZerns;
-    out.regions = regions;
-    out.regions_have_been_expanded = regions_have_been_expanded;
-    return out;
+    data = wf.data.clone();
+    nulledData = wf.nulledData.clone();
+    mask = wf.mask.clone();
+    workData = wf.workData.clone();
+    workMask = wf.workMask.clone();
 }
-
-wavefront wavefront::copyDeep() const
-{
-    wavefront out;
-    out.data = data.clone();
-    out.nulledData = nulledData.clone();
-    out.mask = mask.clone();
-    out.workData = workData.clone();
-    out.workMask = workMask.clone();
-    out.InputZerns = InputZerns;
-    out.zernEnablesApplied = zernEnablesApplied;
-    out.gaussian_diameter = gaussian_diameter;
-    out.gbEnabled = gbEnabled;
-    out.gbValue = gbValue;
-    out.wasSmoothed = wasSmoothed;
-    out.useSANull = useSANull;
-    out.GBSmoothingValue = GBSmoothingValue;
-    out.m_origin = m_origin;
-    out.m_manuallyInverted = m_manuallyInverted;
-    out.name = name;
-    out.lambda = lambda;
-    out.m_outside = m_outside;
-    out.m_inside = m_inside;
-    out.diameter = diameter;
-    out.roc = roc;
-    out.min = min;
-    out.max = max;
-    out.std = std;
-    out.mean = mean;
-    out.dirtyZerns = dirtyZerns;
-    out.regions = regions;
-    out.regions_have_been_expanded = regions_have_been_expanded;
-    return out;
-}
-
-

--- a/wavefront.cpp
+++ b/wavefront.cpp
@@ -22,17 +22,6 @@ wavefront::wavefront():
 {
 }
 
-wavefront::~wavefront()
-{
-
-    data.release();
-    mask.release();
-    workData.release();
-    workMask.release();
-    InputZerns.clear();
-    nulledData.release();
-
-}
 wavefront::wavefront( const wavefront &wf): 
     data(wf.data.clone()),
     nulledData(wf.nulledData.clone()),

--- a/wavefront.cpp
+++ b/wavefront.cpp
@@ -49,6 +49,7 @@ wavefront::wavefront( const wavefront &wf):
     GBSmoothingValue(wf.GBSmoothingValue),
     m_origin(wf.m_origin),
     m_manuallyInverted(wf.m_manuallyInverted),
+    name(wf.name),
     lambda(wf.lambda),
     m_outside(wf.m_outside),
     m_inside(wf.m_inside),
@@ -58,6 +59,8 @@ wavefront::wavefront( const wavefront &wf):
     max(wf.max),
     std(wf.std),
     mean(wf.mean),
-    dirtyZerns(wf.dirtyZerns)
+    dirtyZerns(wf.dirtyZerns),
+    regions(wf.regions),
+    regions_have_been_expanded(wf.regions_have_been_expanded)
 {}
 

--- a/wavefront.h
+++ b/wavefront.h
@@ -37,10 +37,13 @@ class wavefront
 public:
     wavefront();
     ~wavefront() = default;
-    wavefront( const wavefront &wf); // copy constructor doing deep copy of cv::Mat
-    wavefront( wavefront && ) = delete;	// move constructor, deleted because unused
-    wavefront& operator=( const wavefront & ) = default; // copy operator not doing deep copy of cv::mat
-    wavefront& operator=(wavefront &&) = delete; // move operator, deleted because unused
+    wavefront(const wavefront&) = delete;
+    wavefront(wavefront&&) noexcept = default;
+    wavefront& operator=(const wavefront&) = delete;
+    wavefront& operator=(wavefront&&) noexcept = default;
+
+    wavefront copyShallow() const;
+    wavefront copyDeep() const;
 
     cv::Mat_<double> data;
     cv::Mat_<double> nulledData;

--- a/wavefront.h
+++ b/wavefront.h
@@ -37,13 +37,11 @@ class wavefront
 public:
     wavefront();
     ~wavefront() = default;
-    wavefront(const wavefront&) = delete;
-    wavefront(wavefront&&) noexcept = default;
-    wavefront& operator=(const wavefront&) = delete;
-    wavefront& operator=(wavefront&&) noexcept = default;
-
-    wavefront copyShallow() const;
-    wavefront copyDeep() const;
+    wavefront( const wavefront &wf) = default;
+    wavefront( wavefront && ) = default;
+    wavefront& operator=( const wavefront & ) = default;
+    wavefront& operator=(wavefront &&) = default;
+    void cloneMatricesFrom(const wavefront &wf);
 
     cv::Mat_<double> data;
     cv::Mat_<double> nulledData;

--- a/wavefront.h
+++ b/wavefront.h
@@ -36,7 +36,7 @@ class wavefront
 {
 public:
     wavefront();
-    ~wavefront();
+    ~wavefront() = default;
     wavefront( const wavefront &wf); // copy constructor doing deep copy of cv::Mat
     wavefront( wavefront && ) = delete;	// move constructor, deleted because unused
     wavefront& operator=( const wavefront & ) = default; // copy operator not doing deep copy of cv::mat

--- a/zernikesmoothingdlg.cpp
+++ b/zernikesmoothingdlg.cpp
@@ -12,7 +12,7 @@ ZernikeSmoothingDlg::ZernikeSmoothingDlg(wavefront &wf, QWidget *parent) :
     p_wf = &wf;
 
     m_zp = new zernikeProcess;
-    m_wf = wf.copyShallow();
+    m_wf = wf;
     theZerns = wf.InputZerns;
     m_noOfTerms = m_zp->getNumberOfTerms();
     m_zernEnables = std::vector<bool>(m_noOfTerms);
@@ -115,7 +115,7 @@ cv::Mat makeSurfaceFromZerns(int width, zernikeProcess &zp, std::vector<double> 
 void ZernikeSmoothingDlg::on_createWaveFront_clicked()
 {
     QApplication::setOverrideCursor(Qt::WaitCursor);
-    m_wf = p_wf->copyShallow();
+    m_wf = *p_wf;
     if (!ui->useCurrentZernySet->isChecked()){
         std::vector<double> tzerns = m_zp->ZernFitWavefront(m_wf);
         if (tzerns.size() == 0){

--- a/zernikesmoothingdlg.cpp
+++ b/zernikesmoothingdlg.cpp
@@ -12,7 +12,7 @@ ZernikeSmoothingDlg::ZernikeSmoothingDlg(wavefront &wf, QWidget *parent) :
     p_wf = &wf;
 
     m_zp = new zernikeProcess;
-    m_wf = wf;
+    m_wf = wf.copyShallow();
     theZerns = wf.InputZerns;
     m_noOfTerms = m_zp->getNumberOfTerms();
     m_zernEnables = std::vector<bool>(m_noOfTerms);
@@ -115,7 +115,7 @@ cv::Mat makeSurfaceFromZerns(int width, zernikeProcess &zp, std::vector<double> 
 void ZernikeSmoothingDlg::on_createWaveFront_clicked()
 {
     QApplication::setOverrideCursor(Qt::WaitCursor);
-    m_wf = *p_wf;
+    m_wf = p_wf->copyShallow();
     if (!ui->useCurrentZernySet->isChecked()){
         std::vector<double> tzerns = m_zp->ZernFitWavefront(m_wf);
         if (tzerns.size() == 0){


### PR DESCRIPTION
See issue #62 for details.
I only cleaned the manual destructor and added init for some missing fields of constructor.

I decided to not do a deep copy inside move constructor because it could have performance impact. I'm supposing Dale did it like this on purpose.
Cleaner solution would be to create explicit functions "deepCopy" and "lightCopy" but as it works I prefer not to touch.

code is documented so just be careful
```
    wavefront( const wavefront &wf); // copy constructor doing deep copy of cv::Mat
    wavefront( wavefront && ) = delete;	// move constructor, deleted because unused
    wavefront& operator=( const wavefront & ) = default; // copy operator not doing deep copy of cv::mat
    wavefront& operator=(wavefront &&) = delete; // move operator, deleted because unused
```

consider this close #62