### PR TITLE
Fix potential dip in profile plot when using Gaussian blur + minor display issues

### DIFF
--- a/contourplot.cpp
+++ b/contourplot.cpp
@@ -254,10 +254,15 @@ double SpectrogramData::value( double x, double y ) const
     if (y >= m_wf->workData.rows || x >= m_wf->workData.cols || y < 0 || x < 0){
         return -10.0;
     }
-    if ((m_wf->workMask.at<uint8_t>((int)y,(int)x)) != 255){
+    int ix = qRound(x);
+    int iy = qRound(y);
+    if (iy >= m_wf->workData.rows || ix >= m_wf->workData.cols || iy < 0 || ix < 0){
+        return -10.0;
+    }
+    if ((m_wf->workMask.at<uint8_t>(iy,ix)) != 255){
         return -10;
     }
-    return  (m_wf->workData(y,x)* m_wf->lambda/outputLambda) -zOffset;
+    return  (m_wf->workData(iy,ix)* m_wf->lambda/outputLambda) -zOffset;
 
 }
 
@@ -402,8 +407,8 @@ void ContourPlot::ruler(){
             double sina = sin(radians);
             double cosa = cos(radians);
             // move to start
-            int startx =  -half * cosa;
-            int starty =  -half * sina;
+            int startx =  qRound(-half * cosa);
+            int starty =  qRound(-half * sina);
             radials.moveTo( half + startx,half + starty);
             // line to end
             int endx = half - startx;
@@ -486,8 +491,8 @@ void ContourPlot::drawProfileLine(const double angle){
     QPainterPath radials;
     int half = m_wf->data.rows/2.;
     // move to start
-    int startx =  -half * cosa;
-    int starty =  -half * sina;
+    int startx =  qRound(-half * cosa);
+    int starty =  qRound(-half * sina);
     radials.moveTo( half + startx,half + starty);
     // line to end
     int endx = half - startx;

--- a/contourtools.cpp
+++ b/contourtools.cpp
@@ -94,6 +94,9 @@ void ContourTools::setWaveRange(double val){
 void ContourTools::setMinMaxValues(double min, double max){
     m_min = min;
     m_max = max;
+    ui->errorRangeSpin->blockSignals(true);
+    ui->errorRangeSpin->setValue(m_max - m_min);
+    ui->errorRangeSpin->blockSignals(false);
     ui->minSB->blockSignals(true);
     ui->maxSB->blockSignals(true);
     ui->minSB->setValue(min);

--- a/foucaultview.cpp
+++ b/foucaultview.cpp
@@ -285,7 +285,7 @@ QImage *foucaultView::render(){
 
 void foucaultView::saveRonchiImage(){
     const QPixmap pm = ui->ronchiViewLb->pixmap(Qt::ReturnByValue);
-    pm.save(getSaveFileName("foucault"));
+    pm.save(getSaveFileName("ronchi"));
 
 }
 void foucaultView::saveFoucaultImage(){

--- a/profileplot.cpp
+++ b/profileplot.cpp
@@ -444,9 +444,9 @@ QPolygonF ProfilePlot::createProfile(double units, const wavefront *wf, bool all
             e = md.m_verticalAxis / md.diameter;
         }
 
-        // Calculate matrix coordinates
-        int dx = radn * cos(g_angle + M_PI_2) + wf->m_outside.m_center.x();
-        int dy = -radn * e * sin(g_angle + M_PI_2) + wf->m_outside.m_center.y();
+        // Round to the nearest pixel to avoid 1-pixel endpoint errors at cardinal angles.
+        int dx = qRound(radn * cos(g_angle + M_PI_2) + wf->m_outside.m_center.x());
+        int dy = qRound(-radn * e * sin(g_angle + M_PI_2) + wf->m_outside.m_center.y());
 
         // Boundary Check: Ignore points outside the matrix
         if (dy >= wf->data.rows || dx >= wf->data.cols || dy < 0 || dx < 0) {

--- a/psi_dlg.cpp
+++ b/psi_dlg.cpp
@@ -293,10 +293,10 @@ void PSI_dlg::plot(QVector<double> phases, int iteration, double sdp){
             double angle = phases[i];
             double angle2 = phases[i+1];
 
-            int x1 = half - rlast * cos(angle + M_PI/2.);
-            int x2 = half - r * cos(angle2 + M_PI/2.);
-            int y1 = half - rlast * sin(angle + M_PI/2.);
-            int y2 = half - r * sin(angle2+ M_PI/2.);
+            int x1 = qRound(half - rlast * cos(angle + M_PI/2.));
+            int x2 = qRound(half - r * cos(angle2 + M_PI/2.));
+            int y1 = qRound(half - rlast * sin(angle + M_PI/2.));
+            int y2 = qRound(half - r * sin(angle2+ M_PI/2.));
             // qDebug() << "angle1" << angle * k << angle2 * k;
             while (angle < 0)
                 angle = (2 * M_PI) + angle;

--- a/psiphasedisplay.cpp
+++ b/psiphasedisplay.cpp
@@ -54,10 +54,10 @@ void PSIphaseDisplay::plot(QVector<double> phases, int iteration, double sdp){
         double angle = phases[i];
         double angle2 = phases[i+1];
 
-        int x1 = half - rlast * cos(angle + M_PI/2.);
-        int x2 = half - r * cos(angle2 + M_PI/2.);
-        int y1 = half - rlast * sin(angle + M_PI/2.);
-        int y2 = half - r * sin(angle2+ M_PI/2.);
+        int x1 = qRound(half - rlast * cos(angle + M_PI/2.));
+        int x2 = qRound(half - r * cos(angle2 + M_PI/2.));
+        int y1 = qRound(half - rlast * sin(angle + M_PI/2.));
+        int y2 = qRound(half - r * sin(angle2+ M_PI/2.));
        // qDebug() << "angle1" << angle * k << angle2 * k;
         while (angle < 0)
             angle = (2 * M_PI) + angle;

--- a/utils.cpp
+++ b/utils.cpp
@@ -227,9 +227,10 @@ void CropGaussianBlur(const cv::Mat &in_, cv::Mat &out, int kernelSize, const Ci
     double radius2 = (outside.m_radius-2)*(outside.m_radius-2);
     for (int x=0; x<width; x++) {
         double dx = (cx-x)*(cx-x);
-        for (int y=0; y<width; y++) {
+        for (int y=0; y<height; y++) {
             double dy = (cy-y)*(cy-y);
-            if ((dx+dy) >= radius2) {
+            // Keep boundary pixels inside, consistent with fillCircle() mask creation.
+            if ((dx+dy) > radius2) {
                 mask.at<double>(y,x) = 1e-5; // can't use zero or we get divide by zero issues later (in cells we don't care about)
                 in.at<double>(y,x) = 0;
             }
@@ -246,9 +247,9 @@ void CropGaussianBlur(const cv::Mat &in_, cv::Mat &out, int kernelSize, const Ci
     if (center.m_radius > 0) {
         for (int x=0; x<width; x++) {
             double dx = (cx-x)*(cx-x);
-            for (int y=0; y<width; y++) {
+            for (int y=0; y<height; y++) {
                 double dy = (cy-y)*(cy-y);
-                if ((dx+dy) < radius2) {
+                if ((dx+dy) <= radius2) {
                     mask.at<double>(y,x) = 1e-5; // can't use zero or we get divide by zero issues later (in cells we don't care about)
                     in.at<double>(y,x) = 0;
                 }
@@ -292,9 +293,9 @@ void CropGaussianBlur(const cv::Mat &in_, cv::Mat &out, int kernelSize, const Ci
 
     for (int x=0; x<width; x++) {
         double dx2 = (cx-x)*(cx-x);
-        for (int y=0; y<width; y++) {
+        for (int y=0; y<height; y++) {
             double dy2 = (cy-y)*(cy-y);
-            if ((dx2+dy2) >= radius2) {
+            if ((dx2+dy2) > radius2) {
                 out.at<double>(y,x) = 0;
             }
         }
@@ -310,9 +311,9 @@ void CropGaussianBlur(const cv::Mat &in_, cv::Mat &out, int kernelSize, const Ci
     if (center.m_radius > 0) {
         for (int x=0; x<width; x++) {
             double dx = (cx-x)*(cx-x);
-            for (int y=0; y<width; y++) {
+            for (int y=0; y<height; y++) {
                 double dy = (cy-y)*(cy-y);
-                if ((dx+dy) < radius2) {
+                if ((dx+dy) <= radius2) {
                     out.at<double>(y,x) = 0;
                 }
             }


### PR DESCRIPTION
fix #333 

Problem was due to Gaussian blur not using same inclusive/exclusive boundaries as cicle mask code (second commit)   
I also changed some float to int truncature into rounding as small epsilon could cause issues with sin/cos (first commit).

Fix #319 
Fix #317