### PR TITLE
zernike enable table is saved for each wft. Display diff

### DIFF
--- a/surfacemanager.cpp
+++ b/surfacemanager.cpp
@@ -470,10 +470,14 @@ void SurfaceManager::generateSurfacefromWavefront(wavefront * wf){
     wf->nulledData.release();
 }
 cv::Mat SurfaceManager::computeWaveFrontFromZernikes(int wx, int wy, std::vector<double> &zerns, QVector<int> zernsToUse){
-    double rad = getCurrent()->m_outside.m_radius;
-    double xcen = (wx-1)/2, ycen = (wy-1)/2;
-
+    wavefront *currentWf = getCurrent();
     cv::Mat result = cv::Mat::zeros(wy,wx, numType);
+    if (currentWf == nullptr) {
+        return result;
+    }
+
+    double rad = currentWf->m_outside.m_radius;
+    double xcen = (wx-1)/2, ycen = (wy-1)/2;
 
     double rho;
 
@@ -482,9 +486,7 @@ cv::Mat SurfaceManager::computeWaveFrontFromZernikes(int wx, int wy, std::vector
         if (value > maxZernToUse)
             maxZernToUse = value;
     }
-
-
-    std::vector<bool> &en = (getCurrent()->zernEnablesApplied.empty()) ? zernEnables : getCurrent()->zernEnablesApplied;
+    std::vector<bool> &en = (currentWf->zernEnablesApplied.empty()) ? zernEnables : currentWf->zernEnablesApplied;
     mirrorDlg *md = mirrorDlg::get_Instance();
     for (int i = 0; i <  wx; ++i)
     {

--- a/surfacemanager.cpp
+++ b/surfacemanager.cpp
@@ -931,7 +931,22 @@ void SurfaceManager::computeMetrics(wavefront *wf){
     wf->min = mmin * md->lambda/outputLambda;
     wf->max = mmax * md->lambda/outputLambda;
 
-    ((MainWindow*)parent())->zernTablemodel->setAppliedEnables(&wf->zernEnablesApplied);
+    // let zernTableModel know state of currently selected wavefronts zernike state (which were checked/unchecked/both)
+    QList<int> doThese =  m_surfaceTools->SelectedWaveFronts();
+    bool bFirst=true;
+    foreach(int ndx , doThese){
+        wavefront * each_wf = m_wavefronts[ndx];
+        if (bFirst) {
+            ((MainWindow*)parent())->zernTablemodel->setAppliedEnables(&each_wf->zernEnablesApplied);
+            bFirst = false;
+        } else {
+            ((MainWindow*)parent())->zernTablemodel->addAppliedEnables(&each_wf->zernEnablesApplied);
+        }
+    }
+
+
+
+
     ((MainWindow*)(parent()))->zernTablemodel->setValues(wf->InputZerns, !wf->useSANull);
     ((MainWindow*)parent())-> zernTablemodel->update();
     ((MainWindow*)(parent()))->updateMetrics(*wf);

--- a/surfacemanager.cpp
+++ b/surfacemanager.cpp
@@ -350,6 +350,11 @@ void SurfaceManager::generateSurfacefromWavefront(int wavefrontNdx) {
 
 void SurfaceManager::generateSurfacefromWavefront(wavefront * wf){
     zernikeProcess &zp = *zernikeProcess::get_Instance();
+    if (wf->zernEnablesApplied.empty()) {
+        wf->zernEnablesApplied = zernEnables;
+    } else if (wf->zernEnablesApplied.size() != zernEnables.size()) {
+        wf->zernEnablesApplied.resize(zernEnables.size(), true);
+    }
     m_GB_enabled = wf->gbEnabled;
     m_gbValue = wf->gbValue;
     if (wf->dirtyZerns){
@@ -426,6 +431,7 @@ void SurfaceManager::generateSurfacefromWavefront(wavefront * wf){
 		// AUTO INVERT CODE ENDS HERE/
 		//
 
+        ((MainWindow*)parent())-> zernTablemodel->setAppliedEnables(&wf->zernEnablesApplied);
         ((MainWindow*)parent())-> zernTablemodel->setValues(wf->InputZerns, !wf->useSANull);
         ((MainWindow*)parent())-> zernTablemodel->update();
         // fill in void from obstruction of igram.
@@ -435,7 +441,7 @@ void SurfaceManager::generateSurfacefromWavefront(wavefront * wf){
         //cv::Mat tiltremoved = zp.null_unwrapped(*wf, wf->InputZerns, zernEnables, 0,3);
         //wf->data = tiltremoved;
         //zp.unwrap_to_zernikes(*wf);
-        wf->nulledData = zp.null_unwrapped(*wf, wf->InputZerns, zernEnables,0,Z_TERMS   );
+        wf->nulledData = zp.null_unwrapped(*wf, wf->InputZerns, wf->zernEnablesApplied,0,Z_TERMS   );
         wf->dirtyZerns = false;
     }
 
@@ -478,7 +484,7 @@ cv::Mat SurfaceManager::computeWaveFrontFromZernikes(int wx, int wy, std::vector
     }
 
 
-    std::vector<bool> &en = zernEnables;
+    std::vector<bool> &en = (getCurrent()->zernEnablesApplied.empty()) ? zernEnables : getCurrent()->zernEnablesApplied;
     mirrorDlg *md = mirrorDlg::get_Instance();
     for (int i = 0; i <  wx; ++i)
     {
@@ -538,7 +544,7 @@ SurfaceManager::SurfaceManager(QObject *parent, surfaceAnalysisTools *tools,
     m_surfaceTools(tools),m_profilePlot(profilePlot), m_contourView(contourView),
     m_SurfaceGraph(glPlot), m_metrics(mets),m_gbValue(21),
     m_GB_enabled(false),m_currentNdx(-1),m_standAvg(0),insideOffset(0),outsideOffset(0),
-    m_inverseMode(invNOTSET),m_ignoreInverse(false), m_standAstigWizard(nullptr), workToDo(0), m_wftStats(0)
+    m_inverseMode(invNOTSET),m_ignoreInverse(false), m_standAstigWizard(nullptr), workToDo(0), m_applyFloatingZernEnables(false), m_wftStats(0)
 {
 
     okToUpdateSurfacesOnGenerateComplete = true;
@@ -923,7 +929,7 @@ void SurfaceManager::computeMetrics(wavefront *wf){
     wf->min = mmin * md->lambda/outputLambda;
     wf->max = mmax * md->lambda/outputLambda;
 
-
+    ((MainWindow*)parent())->zernTablemodel->setAppliedEnables(&wf->zernEnablesApplied);
     ((MainWindow*)(parent()))->zernTablemodel->setValues(wf->InputZerns, !wf->useSANull);
     ((MainWindow*)parent())-> zernTablemodel->update();
     ((MainWindow*)(parent()))->updateMetrics(*wf);
@@ -960,6 +966,7 @@ void SurfaceManager::computeZerns()
 {
     QList<int> doThese =  m_surfaceTools->SelectedWaveFronts();
     workToDo = doThese.size();
+    m_applyFloatingZernEnables = !doThese.isEmpty();
     mirrorDlg &md = *mirrorDlg::get_Instance();
     foreach(int ndx , doThese){
         wavefront &wf = *m_wavefronts[ndx];
@@ -1143,6 +1150,7 @@ void SurfaceManager::createSurfaceFromPhaseMap(cv::Mat phase, CircleOutline outs
     wf->diameter = md->diameter;
     wf->lambda = md->lambda;
     wf->roc = md->roc;
+    wf->zernEnablesApplied = zernEnables;
     wf->gbEnabled = m_GB_enabled;
     wf->gbValue = m_gbValue;
     wf->dirtyZerns = true;
@@ -1435,6 +1443,7 @@ wavefront * SurfaceManager::readWaveFront(const QString &fileName){
     wf->diameter = diam;
     wf->roc = roc;
     wf->lambda = lambda;
+    wf->zernEnablesApplied = zernEnables;
     wf->gbEnabled = m_GB_enabled;
     wf->gbValue = m_gbValue;
     wf->wasSmoothed = false;
@@ -1637,7 +1646,12 @@ void SurfaceManager::backGroundUpdate(){
     workToDo = doThese.size();
     pd->setLabelText("Updating Selected Surfaces");
     pd->setRange(0,doThese.size());
+    const bool applyFloatingZerns = m_applyFloatingZernEnables;
+    m_applyFloatingZernEnables = false;
     foreach (int i, doThese){
+        if (applyFloatingZerns) {
+            m_wavefronts[i]->zernEnablesApplied = zernEnables;
+        }
         m_wavefronts[i]->dirtyZerns = true;
         m_wavefronts[i]->wasSmoothed = false;
         makeMask(i);
@@ -3065,7 +3079,10 @@ void SurfaceManager::report(){
         int half = Z_TERMS/2 +2;
         for (int i = 3; i < half; ++i){
             double val = wf->InputZerns[i];
-            bool enabled = zernEnables[i];
+            bool enabled = true;
+            if (static_cast<size_t>(i) < wf->zernEnablesApplied.size()) {
+                enabled = wf->zernEnablesApplied[i];
+            }
             if ( i == 3 && m_surfaceTools->m_useDefocus){
                 val = m_surfaceTools->m_defocus;
                 enabled = true;
@@ -3099,9 +3116,13 @@ void SurfaceManager::report(){
 
         for (int i = half; i < Z_TERMS; ++i){
             double val = wf->InputZerns[i];
+            bool enabled = true;
+            if (static_cast<size_t>(i) < wf->zernEnablesApplied.size()) {
+                enabled = wf->zernEnablesApplied[i];
+            }
             zerns.append("<tr><td>" + QString(zernsNames[i]) + "</td><td><table width = '100%'><tr><td>" + QString("%1</td><td>%2</td></tr></table>").arg(
                                                                                                                              val, 6, 'f', 3).arg(computeRMS(i,val), 6, 'f', 3) + "</td><td>" +
-                         QString((zernEnables[i]) ? QString("") : QString("Disabled")) + "</td></tr>");
+                         QString((enabled) ? QString("") : QString("Disabled")) + "</td></tr>");
         }
         zerns.append("</table></td></tr></table></p>");
 

--- a/surfacemanager.h
+++ b/surfacemanager.h
@@ -132,6 +132,7 @@ private:
     QPointer<standAstigWizard> m_standAstigWizard;
     int workToDo;
     int workProgress;
+    bool m_applyFloatingZernEnables;
 
     wftStats *m_wftStats;
 

--- a/wavefront.cpp
+++ b/wavefront.cpp
@@ -18,7 +18,7 @@
 #include "wavefront.h"
 
 wavefront::wavefront():
-    gaussian_diameter(0.),gbEnabled(false),gbValue(20.),wasSmoothed(false),useSANull(true),GBSmoothingValue(0.),m_origin(WavefrontOrigin::Unknown),m_manuallyInverted(false),dirtyZerns(true),regions_have_been_expanded(false)
+    zernEnablesApplied(),gaussian_diameter(0.),gbEnabled(false),gbValue(20.),wasSmoothed(false),useSANull(true),GBSmoothingValue(0.),m_origin(WavefrontOrigin::Unknown),m_manuallyInverted(false),dirtyZerns(true),regions_have_been_expanded(false)
 {
 }
 
@@ -40,6 +40,7 @@ wavefront::wavefront( const wavefront &wf):
     workData(wf.workData.clone()),
     workMask(wf.workMask.clone()),
     InputZerns(wf.InputZerns),
+    zernEnablesApplied(wf.zernEnablesApplied),
     gaussian_diameter(wf.gaussian_diameter),
     gbEnabled(wf.gbEnabled),
     gbValue(wf.gbValue),

--- a/wavefront.h
+++ b/wavefront.h
@@ -48,6 +48,7 @@ public:
     cv::Mat_<double> workData;
     cv::Mat_<uint8_t> workMask;
     std::vector<double> InputZerns;
+    std::vector<bool> zernEnablesApplied;
     double gaussian_diameter;
     bool gbEnabled;
     double gbValue;

--- a/zernikedlg.cpp
+++ b/zernikedlg.cpp
@@ -30,7 +30,7 @@
 // Zernike_terms message handlers
 
 ZernTableModel::ZernTableModel(QObject *parent, std::vector<bool> *enables, bool editEnable)
-    :QAbstractTableModel(parent),  m_enables(enables),canEdit(editEnable), m_nulled(false), m_appliedEnables(nullptr)
+    :QAbstractTableModel(parent),  m_enables(enables),canEdit(editEnable), m_nulled(false)
 {
     zernikeProcess &zp = *zernikeProcess::get_Instance();
     values = std::vector<double>(zp.m_norms.size(), 0.);
@@ -49,7 +49,33 @@ void ZernTableModel::setValues(const std::vector<double> &vals, bool nulled){
 }
 
 void ZernTableModel::setAppliedEnables(const std::vector<bool> *appliedEnables){
-    m_appliedEnables = appliedEnables;
+    if (appliedEnables == nullptr) return;
+    if (appliedEnables->size() > m_appliedEnables.size())
+        m_appliedEnables.resize(appliedEnables->size());
+    for (size_t i = 0; i < appliedEnables->size(); ++i) {
+        if ((*appliedEnables)[i])
+            m_appliedEnables[i] = enEnables::Enabled;
+        else
+            m_appliedEnables[i] = enEnables::Disabled;
+    }
+    update();
+}
+
+void ZernTableModel::addAppliedEnables(const std::vector<bool> *appliedEnables){
+    if (appliedEnables == nullptr) return;
+    if (appliedEnables->size() > m_appliedEnables.size())
+        m_appliedEnables.resize(appliedEnables->size());
+    for (size_t i = 0; i < appliedEnables->size(); ++i) {
+        if ((*appliedEnables)[i]) {
+            // new zernike is enabled
+            if (m_appliedEnables[i] == enEnables::Disabled)
+                m_appliedEnables[i] = enEnables::Mixed;
+        } else {
+            // new zernike is disabled
+            if (m_appliedEnables[i] == enEnables::Enabled)
+                m_appliedEnables[i] = enEnables::Mixed;
+        }
+    }
     update();
 }
 
@@ -57,7 +83,6 @@ void ZernTableModel::update(){
     QModelIndex topLeft = index(0, 0);
     QModelIndex bottomRight = index(rowCount() - 1, columnCount() - 1);
     emit dataChanged(topLeft, bottomRight);
-
 }
 
 void ZernTableModel::resizeRows(const int rowCnt){
@@ -109,14 +134,13 @@ QVariant ZernTableModel::data(const QModelIndex &index, int role) const
     {
         if (index.column() == 0){
             QString marker;
-            if (m_appliedEnables != nullptr &&
-                index.row() < (int)m_appliedEnables->size() &&
+            if (index.row() < (int)m_appliedEnables.size() &&
                 index.row() < (int)m_enables->size()) {
                 const bool floatingEnabled = m_enables->at(index.row());
-                const bool appliedEnabled = m_appliedEnables->at(index.row());
-                if (floatingEnabled && !appliedEnabled) {
+                const enEnables appliedEnabled = m_appliedEnables[index.row()];
+                if (floatingEnabled && appliedEnabled != enEnables::Enabled) {
                     marker = "[+] ";
-                } else if (!floatingEnabled && appliedEnabled) {
+                } else if (!floatingEnabled && appliedEnabled != enEnables::Disabled) {
                     marker = "[-] ";
                 }
             }
@@ -154,17 +178,19 @@ QVariant ZernTableModel::data(const QModelIndex &index, int role) const
             return m_enables->at(index.row()) ? Qt::Checked : Qt::Unchecked;
         }
     }
-    if (role == Qt::ToolTipRole && index.column() == 0 && m_appliedEnables != nullptr &&
-        index.row() < (int)m_appliedEnables->size() && index.row() < (int)m_enables->size()) {
+    if (role == Qt::ToolTipRole && index.column() == 0 &&
+        index.row() < (int)m_appliedEnables.size() && index.row() < (int)m_enables->size()) {
         const bool floatingEnabled = m_enables->at(index.row());
-        const bool appliedEnabled = m_appliedEnables->at(index.row());
-        if (floatingEnabled && !appliedEnabled) {
+        const enEnables appliedEnabled = m_appliedEnables[index.row()];
+        if (floatingEnabled && appliedEnabled != enEnables::Enabled) {
             return QString("Will be enabled on recompute for this wavefront.");
         }
-        if (!floatingEnabled && appliedEnabled) {
+        if (!floatingEnabled && appliedEnabled != enEnables::Disabled) {
             return QString("Will be disabled on recompute for this wavefront.");
         }
-        return QString("No change for this wavefront on recompute.");
+        if (floatingEnabled == false)
+            return QString("This Zernike has been subtracted out from the wavefront.");
+        return QString("Uncheck to remove this component from the wavefront.");
     }
     return QVariant();
 }

--- a/zernikedlg.cpp
+++ b/zernikedlg.cpp
@@ -30,7 +30,7 @@
 // Zernike_terms message handlers
 
 ZernTableModel::ZernTableModel(QObject *parent, std::vector<bool> *enables, bool editEnable)
-    :QAbstractTableModel(parent),  m_enables(enables),canEdit(editEnable), m_nulled(false)
+    :QAbstractTableModel(parent),  m_enables(enables),canEdit(editEnable), m_nulled(false), m_appliedEnables(nullptr)
 {
     zernikeProcess &zp = *zernikeProcess::get_Instance();
     values = std::vector<double>(zp.m_norms.size(), 0.);
@@ -46,6 +46,11 @@ void ZernTableModel::setValues(const std::vector<double> &vals, bool nulled){
     QModelIndex bottomRight = index(rowCount() - 1, columnCount() - 1);
     update();
     emit dataChanged(topLeft, bottomRight);
+}
+
+void ZernTableModel::setAppliedEnables(const std::vector<bool> *appliedEnables){
+    m_appliedEnables = appliedEnables;
+    update();
 }
 
 void ZernTableModel::update(){
@@ -103,13 +108,25 @@ QVariant ZernTableModel::data(const QModelIndex &index, int role) const
     if (role == Qt::DisplayRole)
     {
         if (index.column() == 0){
+            QString marker;
+            if (m_appliedEnables != nullptr &&
+                index.row() < (int)m_appliedEnables->size() &&
+                index.row() < (int)m_enables->size()) {
+                const bool floatingEnabled = m_enables->at(index.row());
+                const bool appliedEnabled = m_appliedEnables->at(index.row());
+                if (floatingEnabled && !appliedEnabled) {
+                    marker = "[+] ";
+                } else if (!floatingEnabled && appliedEnabled) {
+                    marker = "[-] ";
+                }
+            }
             if (index.row() <= 48)
-                return zernsNames[index.row()];
+                return marker + zernsNames[index.row()];
             else {
                 int row = index.row();
                 int sr = floor(sqrt(row+1));
 
-                return (QString("%1 %2").arg(index.row()).arg(
+                return marker + (QString("%1 %2").arg(index.row()).arg(
                       ( sr * sr == index.row()+1)? "Spherical" : ""));
             }
         }
@@ -137,6 +154,18 @@ QVariant ZernTableModel::data(const QModelIndex &index, int role) const
             return m_enables->at(index.row()) ? Qt::Checked : Qt::Unchecked;
         }
     }
+    if (role == Qt::ToolTipRole && index.column() == 0 && m_appliedEnables != nullptr &&
+        index.row() < (int)m_appliedEnables->size() && index.row() < (int)m_enables->size()) {
+        const bool floatingEnabled = m_enables->at(index.row());
+        const bool appliedEnabled = m_appliedEnables->at(index.row());
+        if (floatingEnabled && !appliedEnabled) {
+            return QString("Will be enabled on recompute for this wavefront.");
+        }
+        if (!floatingEnabled && appliedEnabled) {
+            return QString("Will be disabled on recompute for this wavefront.");
+        }
+        return QString("No change for this wavefront on recompute.");
+    }
     return QVariant();
 }
 bool ZernTableModel::setData(const QModelIndex & index, const QVariant & value, int role)
@@ -152,6 +181,7 @@ bool ZernTableModel::setData(const QModelIndex & index, const QVariant & value, 
     if (role == Qt::CheckStateRole){
         m_enables->at(index.row()) = value.toBool();
     }
+    emit dataChanged(this->index(index.row(), 0), this->index(index.row(), 1));
     return true;
 }
 

--- a/zernikedlg.h
+++ b/zernikedlg.h
@@ -21,7 +21,6 @@
 #include <QDialog>
 #include <QtCore>
 #include <QtGui>
-#include "zernikedlg.h"
 #include <QAbstractTableModel>
 #include <opencv2/opencv.hpp>
 #include <vector>
@@ -45,6 +44,7 @@ public:
     QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const;
     void setValues(const std::vector<double> &vals, bool nulled);
     void setAppliedEnables(const std::vector<bool> *appliedEnables);
+    void addAppliedEnables(const std::vector<bool> *appliedEnables);
     bool setData(const QModelIndex & index, const QVariant & value, int role = Qt::EditRole);
     Qt::ItemFlags flags(const QModelIndex & index) const ;
     QVariant headerData(int section, Qt::Orientation orientation, int role) const;
@@ -55,9 +55,10 @@ public:
 signals:
     void zernChanged();
 private:
+    enum class enEnables {Enabled, Disabled, Mixed};
     bool canEdit;
     bool m_nulled;
-    const std::vector<bool> *m_appliedEnables;
+    std::vector<enEnables> m_appliedEnables;
 
 };
 

--- a/zernikedlg.h
+++ b/zernikedlg.h
@@ -44,6 +44,7 @@ public:
     void resizeRows(const int rowCnt);
     QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const;
     void setValues(const std::vector<double> &vals, bool nulled);
+    void setAppliedEnables(const std::vector<bool> *appliedEnables);
     bool setData(const QModelIndex & index, const QVariant & value, int role = Qt::EditRole);
     Qt::ItemFlags flags(const QModelIndex & index) const ;
     QVariant headerData(int section, Qt::Orientation orientation, int role) const;
@@ -56,6 +57,7 @@ signals:
 private:
     bool canEdit;
     bool m_nulled;
+    const std::vector<bool> *m_appliedEnables;
 
 };
 


### PR DESCRIPTION
This one also improves #152 . We can probably do it differently and with better visuals but it's enough to validate the intent. 
Just let me know.

you will notice small  + and - before the zernike names. 
It makes it much clearer witch zernike have been used to display a given waveform and what would change if hitting compute button.