### PR TITLE
Fix ignore edge region. Center edge had wrong size and could have wrong coordinates

### DIFF
--- a/surfacemanager.cpp
+++ b/surfacemanager.cpp
@@ -641,8 +641,6 @@ void SurfaceManager::makeMask(wavefront *wf, bool useInsideCircle){
         rado += 1;
     }
 
-    double cx = wf->m_inside.m_center.x();
-    double cy = wf->m_inside.m_center.y();
     cv::Mat mask = cv::Mat::zeros(height,width,CV_8U);
     mirrorDlg &md = *mirrorDlg::get_Instance();
     double rx = radm;
@@ -668,7 +666,8 @@ void SurfaceManager::makeMask(wavefront *wf, bool useInsideCircle){
 
     if (rado > 0 && useInsideCircle) {
         uchar color = 0;
-        fillCircle(mask, cx,cy,rado, &color);
+        // inside circle is not always defined. So we use outside circle coordinates. They are concentric.
+        fillCircle(mask, xm, ym, rado, &color);
     }
 
     // expand the region by 10%

--- a/surfacemanager.cpp
+++ b/surfacemanager.cpp
@@ -637,8 +637,9 @@ void SurfaceManager::makeMask(wavefront *wf, bool useInsideCircle){
     ym = wf->m_outside.m_center.y();
     double radm =wf->m_outside.m_radius + outsideOffset-2;
     double rado = wf->m_inside.m_radius + insideOffset;
-    if (rado > 0)
-        rado += (insideOffset + 1);
+    if(rado > 0){
+        rado += 1;
+    }
 
     double cx = wf->m_inside.m_center.x();
     double cy = wf->m_inside.m_center.y();

--- a/surfacemanager.cpp
+++ b/surfacemanager.cpp
@@ -77,8 +77,6 @@
 #include "utils.h"
 #include "cnpy.h"
 
-cv::Mat theMask;
-cv::Mat deb;
 double outputLambda;
 double bilinear(cv::Mat mat, cv::Mat mask, double x, double y)
 {
@@ -715,7 +713,6 @@ void SurfaceManager::makeMask(wavefront *wf, bool useInsideCircle){
     //line(wf->workMask, Point(s/2, 0), Point(s/2,s),cv::Scalar(0,0,0), 10);
    // line(wf->workMask, Point(0, s/2), Point(s,s/2),cv::Scalar(0,0,0), 10);
     //line(wf->workMask, Point(0, 0), Point(s,s),cv::Scalar(0,0,0), 10);
-    theMask = mask.clone();
 
 
     // add central obstruction (not to be confused with a hole in the mirror - this comes from mirror configuration)

--- a/surfacemanager.cpp
+++ b/surfacemanager.cpp
@@ -643,15 +643,16 @@ void SurfaceManager::makeMask(wavefront *wf, bool useInsideCircle){
 
     cv::Mat mask = cv::Mat::zeros(height,width,CV_8U);
     mirrorDlg &md = *mirrorDlg::get_Instance();
-    double rx = radm;
-    double rx2 = rx * rx;
-    double ry = rx * md.m_verticalAxis/md.diameter;
-    double ry2 = ry * ry;
+
     if (!mirrorDlg::get_Instance()->isEllipse()){
         uchar v = 0xff;
         fillCircle(mask, xm,ym,radm, &v);
     }
     else {
+        double rx = radm;
+        double rx2 = rx * rx;
+        double ry = rx * md.m_verticalAxis/md.diameter;
+        double ry2 = ry * ry;
         for (int y = 0; y < height; ++y){
             for (int x = 0; x < width; ++x){
 

--- a/surfacemanager.cpp
+++ b/surfacemanager.cpp
@@ -758,10 +758,10 @@ void SurfaceManager::ObstructionChanged(){
 
 void SurfaceManager::centerMaskValue(int val){
     insideOffset = val;
-    double mmPerPixel = getCurrent()->diameter/(2 *( m_wavefronts[m_currentNdx]->m_outside.m_radius-1));
-    m_surfaceTools->m_centerMaskLabel->setText(QString("%1 mm").arg(mmPerPixel* val, 6, 'f', 2));
-    makeMask(m_currentNdx);
     wavefront *wf = m_wavefronts[m_currentNdx];
+    double mmPerPixel = wf->diameter/(2 *(wf->m_outside.m_radius-1));
+    m_surfaceTools->m_centerMaskLabel->setText(QString("%1 mm").arg(mmPerPixel* val, 6, 'f', 2));
+    makeMask(wf);
     wf->dirtyZerns = true;
     wf->wasSmoothed = false;
     //emit generateSurfacefromWavefront(m_currentNdx, this);
@@ -771,10 +771,10 @@ void SurfaceManager::centerMaskValue(int val){
 
 void SurfaceManager::outsideMaskValue(int val){
     outsideOffset = val;
-    double mmPerPixel = m_wavefronts[m_currentNdx]->diameter/(2 * (m_wavefronts[m_currentNdx]->m_outside.m_radius));
-    m_surfaceTools->m_edgeMaskLabel->setText(QString("%1 mm").arg(mmPerPixel* val, 6, 'f', 2));
-    makeMask(m_currentNdx);
     wavefront *wf = m_wavefronts[m_currentNdx];
+    double mmPerPixel = wf->diameter/(2 * (wf->m_outside.m_radius));
+    m_surfaceTools->m_edgeMaskLabel->setText(QString("%1 mm").arg(mmPerPixel* val, 6, 'f', 2));
+    makeMask(wf);
     wf->dirtyZerns = true;
     wf->wasSmoothed = false;
     //emit generateSurfacefromWavefront(m_currentNdx, this);

--- a/surfacemanager.cpp
+++ b/surfacemanager.cpp
@@ -1646,6 +1646,7 @@ void SurfaceManager::backGroundUpdate(){
             zp.m_bDontProcessEvents=false;
         }
         catch (int i) {
+            qWarning() << "Exception caught in generateSurfacefromWavefront:" << i;
             break;
         }
     }

--- a/surfacemanager.cpp
+++ b/surfacemanager.cpp
@@ -667,8 +667,15 @@ void SurfaceManager::makeMask(wavefront *wf, bool useInsideCircle){
 
     if (rado > 0 && useInsideCircle) {
         uchar color = 0;
-        // inside circle is not always defined. So we use outside circle coordinates. They are concentric.
-        fillCircle(mask, xm, ym, rado, &color);
+        if(wf->m_inside.isValid()){
+            double cx = wf->m_inside.m_center.x();
+            double cy = wf->m_inside.m_center.y();
+            fillCircle(mask, cx, cy, rado, &color);
+        }
+        else{
+            // inside circle is not always defined. So we use outside circle coordinates.
+            fillCircle(mask, xm, ym, rado, &color);
+        }
     }
 
     // expand the region by 10%
@@ -2904,8 +2911,8 @@ void SurfaceManager::showAllContours(){ //TODO move to contourview would make mo
     }
     QRect rec = QGuiApplication::primaryScreen()->geometry();
     QApplication::setOverrideCursor(Qt::WaitCursor);
-    ContourPlot *plot =new ContourPlot(0,0);//m_contourPlot; //TODO leaking ? 
-    //plot->m_minimal = true; 
+    ContourPlot *plot =new ContourPlot(0,0);//m_contourPlot; //TODO leaking ?
+    //plot->m_minimal = true;
     int cols = dlg.getColumns(); //TODO parameter number of pixels unused here. update the dlg ui
     int width = rec.width()/cols;
     int height = width * .82;
@@ -3498,4 +3505,3 @@ void SurfaceManager::tiltAnalysis(){
    yTilt->attach(pl1);
    pl1->show();
 }
-


### PR DESCRIPTION
Somewhat improves #374. It does not fix all identified issues. What is fixed here:

- inside circle is not always defined. So we use outside circle coordinates. They are concentric anyway.
- `insideOffset` was added twice leading to wrong mask size
